### PR TITLE
Branch v1.2 addlog

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -29,10 +29,7 @@
     <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
 
-  <module name="LineLength">
-    <!-- Checks if a line is too long. -->
-    <property name="max" value="120"/>
-  </module>
+
 
   <!-- All Java AST specific tests live under TreeWalker module. -->
   <module name="TreeWalker">

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -129,18 +129,18 @@ Amigos provides functionality to manage logs, which are essentially detailed not
 
 ### Adding a log: `addlog`
 
-Adds a log to an existing friend in Amigos.
+Adds a log to an existing friend at the specified `INDEX` in Amigos.
+The `INDEX` refers to the index number shown in the displayed person's list.
+Format: `addlog INDEX t/[TITLE] d/[DESCRIPTION]`
 
-Format: `addlog n/[NAME] t/[TITLE] d/[DESCRIPTION]`
-
-* The `NAME` field is compulsory.
+* The `INDEX` field is compulsory.
 * If the `TITLE` argument is provided, then the `DESCRIPTON` argument is optional.
 * If neither `TITLE` nor `DESCRIPTION` arguments are provided, then a GUI
   pop up will prompt the user to key in the title and longer-form text as the description.
 
 Examples:
-* `addlog n/John doe t/has a pet named poki`
-* `addlog n/Andrew Tan t/recommended movies d/the martian, interstellar, three idiots`
+* `addlog 1 t/has a pet named poki`
+* `addlog 2 t/recommended movies d/the martian, interstellar, three idiots`
 
 ### Editing a log: `editlog`
 

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -1,0 +1,171 @@
+package seedu.address.logic.commands;
+
+import java.util.List;
+import java.util.Set;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.person.*;
+import seedu.address.model.tag.Tag;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+/**
+ * Adds a log to a person in the address book.
+ */
+public class AddLogCommand extends Command {
+
+    public static final String COMMAND_WORD = "addlog";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a log to an existing friend in Amigos. "
+            + "Parameters: "
+            +  "INDEX "
+            + PREFIX_TITLE + "TITLE"
+            + "[" + PREFIX_DESCRIPTION + "DESCRIPTION]\n"
+            + "Example: " + COMMAND_WORD + " "
+            + PREFIX_NAME + "John Doe "
+            + PREFIX_TITLE + "Likes apples";
+
+    public static final String MESSAGE_ADD_LOG_SUCCESS = "New log added!";
+    public static final String MESSAGE_DUPLICATE_LOG = "This log already exists for this friend.";
+    public static final String MESSAGE_TITLE_NOT_INCLUDED = "Title of new log must be provided.";
+
+    private final Index index;
+    private final AddLogDescriptor addLogDescriptor;
+
+    /**
+     * Creates an AddLogCommand to add the specified {@code Log} to the
+     * specified {@code Person}.
+     */
+    public AddLogCommand(Index index, AddLogDescriptor addLogDescriptor) {
+        requireAllNonNull(index, addLogDescriptor);
+        this.index = index;
+        this.addLogDescriptor = addLogDescriptor;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        // get list of persons from model
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        // get person and modify
+        if (this.index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+        }
+        Person personToEdit = lastShownList.get(this.index.getZeroBased());
+        Person addedLogPerson = createAddedLogPerson(personToEdit, this.addLogDescriptor);
+
+        // add to address book
+        model.setPerson(personToEdit, addedLogPerson);
+        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_ADD_LOG_SUCCESS);
+    }
+
+    /**
+     * Creates a {@code Person} with the details of {@code personToEdit}, with logs modified by
+     * {@code editPersonLogsDescriptor}.
+     */
+    private static Person createAddedLogPerson(Person personToEdit, AddLogDescriptor addLogDescriptor) throws CommandException {
+        requireAllNonNull(personToEdit, addLogDescriptor);
+        Name name = personToEdit.getName();
+        Phone phone = personToEdit.getPhone();
+        Email email = personToEdit.getEmail();
+        Address address = personToEdit.getAddress();
+        Set<Tag> tags = personToEdit.getTags();
+        List<Log> updatedLogs = addLogDescriptor.getLogs(personToEdit); // main logic encompassed here
+        return new Person(name, phone, email, address, tags, updatedLogs);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AddLogCommand)) {
+            return false;
+        }
+
+        // cast
+        AddLogCommand a = (AddLogCommand) other;
+        return this.index.equals(a.index) &&
+                this.addLogDescriptor.equals(a.addLogDescriptor);
+    }
+
+    /**
+     * Stores the details of the edited log to edit a person's logs with, as well as the person's
+     * original details.
+     */
+    public static class AddLogDescriptor {
+
+        private String newTitle;
+        private String newDescription;
+
+        /**
+         * Constructs a new {@code AddLogDescriptor} object.
+         */
+        public AddLogDescriptor() {
+            this.newTitle = null;
+            this.newDescription = null;
+        }
+
+        public void setNewTitle(String newTitle) {
+            this.newTitle = newTitle;
+        }
+
+        public void setNewDescription(String newDescription) {
+            this.newDescription = newDescription;
+        }
+
+        /**
+         * Returns true if title has been edited.
+         */
+        public boolean isTitleEdited() {
+            return this.newTitle != null;
+        }
+
+        /**
+         * Returns a list of {@code Log} objects that include the {@code Person}'s original logs
+         * as well as the new logs.
+         */
+        public List<Log> getLogs(Person personToEdit) throws CommandException {
+            Log toAdd = new Log(this.newTitle, this.newDescription); // create log to be added
+            if (personToEdit.containsLog(toAdd)) {
+                throw new CommandException(MESSAGE_DUPLICATE_LOG); // ensure not a duplicate log being inserted
+            }
+            List<Log> newLogs = personToEdit.getLogs();
+            newLogs.add(toAdd); // add log
+            return newLogs;
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            // short circuit if same object
+            if (other == this) {
+                return true;
+            }
+
+            // instanceof
+            if (!(other instanceof AddLogDescriptor)) {
+                return false;
+            }
+
+            // cast and check by wrapping into log object
+            AddLogDescriptor a = (AddLogDescriptor) other;
+            Log thisLog = new Log(this.newTitle, this.newDescription);
+            Log otherLog = new Log(a.newTitle, a.newDescription);
+            return thisLog.equals(otherLog);
+        }
+    }
+
+
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -141,7 +141,7 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
-
+            setLogs(toCopy.logs);
         }
 
         /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -19,7 +19,12 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Log;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -19,11 +19,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.CollectionUtil;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -54,7 +50,7 @@ public class EditCommand extends Command {
     private final EditPersonDescriptor editPersonDescriptor;
 
     /**
-     * @param index of the person in the filtered person list to edit
+     * @param index                of the person in the filtered person list to edit
      * @param editPersonDescriptor details to edit the person with
      */
     public EditCommand(Index index, EditPersonDescriptor editPersonDescriptor) {
@@ -98,8 +94,8 @@ public class EditCommand extends Command {
         Email updatedEmail = editPersonDescriptor.getEmail().orElse(personToEdit.getEmail());
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
-
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags);
+        List<Log> updatedLogs = editPersonDescriptor.getLogs().orElse(personToEdit.getLogs());
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedLogs);
     }
 
     @Override
@@ -130,8 +126,10 @@ public class EditCommand extends Command {
         private Email email;
         private Address address;
         private Set<Tag> tags;
+        private List<Log> logs;
 
-        public EditPersonDescriptor() {}
+        public EditPersonDescriptor() {
+        }
 
         /**
          * Copy constructor.
@@ -143,6 +141,7 @@ public class EditCommand extends Command {
             setEmail(toCopy.email);
             setAddress(toCopy.address);
             setTags(toCopy.tags);
+
         }
 
         /**
@@ -199,6 +198,23 @@ public class EditCommand extends Command {
          */
         public Optional<Set<Tag>> getTags() {
             return (tags != null) ? Optional.of(Collections.unmodifiableSet(tags)) : Optional.empty();
+        }
+
+        /**
+         * Sets {@code logs} to this object's {@code logs}.
+         */
+        public void setLogs(List<Log> logs) {
+            this.logs = logs;
+        }
+
+        /**
+         * Returns an unmodifiable list of logs, which throws {@code UnsupportedOperationException}
+         * if modification is attempted.
+         *
+         * @return {@code Optional#empty()} if {@code logs} is null.
+         */
+        public Optional<List<Log>> getLogs() {
+            return (logs != null) ? Optional.of(Collections.unmodifiableList(logs)) : Optional.empty();
         }
 
         @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -25,6 +25,7 @@ public class AddCommandParser implements Parser<AddCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the AddCommand
      * and returns an AddCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public AddCommand parse(String args) throws ParseException {
@@ -41,7 +42,7 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        List<Log> logList =  new ArrayList<Log>();
+        List<Log> logList = new ArrayList<>();
 
         Person person = new Person(name, phone, email, address, tagList, logList);
 

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -7,16 +7,14 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -43,8 +41,9 @@ public class AddCommandParser implements Parser<AddCommand> {
         Email email = ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get());
         Address address = ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get());
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
+        List<Log> logList =  new ArrayList<Log>();
 
-        Person person = new Person(name, phone, email, address, tagList);
+        Person person = new Person(name, phone, email, address, tagList, logList);
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -14,7 +14,12 @@ import java.util.stream.Stream;
 
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Log;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
@@ -49,12 +49,12 @@ public class AddLogCommandParser implements Parser<AddLogCommand> {
         AddLogDescriptor addLogDescriptor = new AddLogDescriptor();
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
-            addLogDescriptor.setNewTitle(ParserUtil.parseTitle(argMultimap.
-                    getValue(PREFIX_TITLE).get()));
+            addLogDescriptor.setNewTitle(ParserUtil.parseTitle(argMultimap
+                    .getValue(PREFIX_TITLE).get()));
         }
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
-            addLogDescriptor.setNewDescription(ParserUtil.parseDescription(argMultimap.
-                    getValue(PREFIX_DESCRIPTION).get()));
+            addLogDescriptor.setNewDescription(ParserUtil.parseDescription(argMultimap
+                    .getValue(PREFIX_DESCRIPTION).get()));
         }
 
         // check validity

--- a/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
@@ -1,0 +1,62 @@
+package seedu.address.logic.parser;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddLogCommand;
+import seedu.address.logic.commands.AddLogCommand.AddLogDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.stream.Stream;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+/**
+ * Parses input arguments and creates a new AddLogCommand object
+ */
+public class AddLogCommandParser implements Parser<AddLogCommand> {
+
+    public AddLogCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        ArgumentMultimap argMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TITLE, PREFIX_DESCRIPTION);
+
+        Index index;
+
+        // ensure title prefix and index are present
+        if (!arePrefixesPresent(argMultimap, PREFIX_TITLE) || !argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE));
+        }
+        // parse
+        try {
+            index = ParserUtil.parseIndex(argMultimap.getPreamble());
+        } catch (ParseException pe) {
+            throw new ParseException((String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE)), pe);
+        }
+
+        // wrap new log into helper class
+        AddLogDescriptor addLogDescriptor = new AddLogDescriptor();
+
+        if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
+            addLogDescriptor.setNewTitle(ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
+        }
+        if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
+            addLogDescriptor.setNewDescription(ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get()));
+        }
+
+        // check validity
+        if (!addLogDescriptor.isTitleEdited()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE));
+        }
+
+        return new AddLogCommand(index, addLogDescriptor);
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
@@ -2,7 +2,9 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.stream.Stream;
 

--- a/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
@@ -1,21 +1,29 @@
 package seedu.address.logic.parser;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.*;
+
+import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddLogCommand;
 import seedu.address.logic.commands.AddLogCommand.AddLogDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import java.util.stream.Stream;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
-import static seedu.address.logic.parser.CliSyntax.*;
 
 /**
  * Parses input arguments and creates a new AddLogCommand object
  */
 public class AddLogCommandParser implements Parser<AddLogCommand> {
 
+    public static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE);
+
+    /**
+     * Parses a string of arguments and creates an {@code AddLogCommand}.
+     *
+     * @throws ParseException if command string is formatted wrongly
+     */
     public AddLogCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
@@ -24,29 +32,34 @@ public class AddLogCommandParser implements Parser<AddLogCommand> {
         Index index;
 
         // ensure title prefix and index are present
-        if (!arePrefixesPresent(argMultimap, PREFIX_TITLE) || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE));
+        if (!arePrefixesPresent(argMultimap, PREFIX_TITLE)) {
+            throw new ParseException(MESSAGE_INVALID_FORMAT);
+        }
+        if (argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(MESSAGE_INVALID_FORMAT);
         }
         // parse
         try {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
         } catch (ParseException pe) {
-            throw new ParseException((String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE)), pe);
+            throw new ParseException(MESSAGE_INVALID_FORMAT, pe);
         }
 
         // wrap new log into helper class
         AddLogDescriptor addLogDescriptor = new AddLogDescriptor();
 
         if (argMultimap.getValue(PREFIX_TITLE).isPresent()) {
-            addLogDescriptor.setNewTitle(ParserUtil.parseTitle(argMultimap.getValue(PREFIX_TITLE).get()));
+            addLogDescriptor.setNewTitle(ParserUtil.parseTitle(argMultimap.
+                    getValue(PREFIX_TITLE).get()));
         }
         if (argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()) {
-            addLogDescriptor.setNewDescription(ParserUtil.parseDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get()));
+            addLogDescriptor.setNewDescription(ParserUtil.parseDescription(argMultimap.
+                    getValue(PREFIX_DESCRIPTION).get()));
         }
 
         // check validity
         if (!addLogDescriptor.isTitleEdited()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE));
+            throw new ParseException(MESSAGE_INVALID_FORMAT);
         }
 
         return new AddLogCommand(index, addLogDescriptor);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,15 +6,7 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -67,6 +59,9 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
+
+        case AddLogCommand.COMMAND_WORD:
+            return new AddLogCommandParser().parse(arguments);
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -6,7 +6,16 @@ import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddLogCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -11,5 +11,8 @@ public class CliSyntax {
     public static final Prefix PREFIX_EMAIL = new Prefix("e/");
     public static final Prefix PREFIX_ADDRESS = new Prefix("a/");
     public static final Prefix PREFIX_TAG = new Prefix("t/");
+    public static final Prefix PREFIX_TITLE = new Prefix("ttl/");
+    public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/"); // TODO: 7/3/2022  modify documentation accordingly
+
 
 }

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -27,6 +27,7 @@ public class EditCommandParser implements Parser<EditCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the EditCommand
      * and returns an EditCommand object for execution.
+     *
      * @throws ParseException if the user input does not conform the expected format
      */
     public EditCommand parse(String args) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -125,15 +125,16 @@ public class ParserUtil {
      *
      * @throws ParseException if the given {@code title} is invalid.
      */
-    public static String parseTitle(String title) throws ParseException { // TODO: 8/3/2022 refactor into Title object next time
+    public static String parseTitle(String title) throws ParseException {
         requireNonNull(title);
         if (!Log.isValidTitle(title)) {
             throw new ParseException(Log.TITLE_CONSTRAINTS);
         }
-        return title;
+        return title; // TODO: 8/3/2022 refactor into Title object next time
     }
 
-    public static String parseDescription(String description) throws ParseException { // TODO: 8/3/2022  refactor into Description object
+    // TODO: 8/3/2022  refactor into Description object
+    public static String parseDescription(String description) throws ParseException {
         return description; // no restrictions on description at the moment
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,7 +9,11 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Log;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,10 +9,7 @@ import java.util.Set;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -25,6 +22,7 @@ public class ParserUtil {
     /**
      * Parses {@code oneBasedIndex} into an {@code Index} and returns it. Leading and trailing whitespaces will be
      * trimmed.
+     *
      * @throws ParseException if the specified index is invalid (not non-zero unsigned integer).
      */
     public static Index parseIndex(String oneBasedIndex) throws ParseException {
@@ -121,4 +119,23 @@ public class ParserUtil {
         }
         return tagSet;
     }
+
+    /**
+     * Parses a String title.
+     *
+     * @throws ParseException if the given {@code title} is invalid.
+     */
+    public static String parseTitle(String title) throws ParseException { // TODO: 8/3/2022 refactor into Title object next time
+        requireNonNull(title);
+        if (!Log.isValidTitle(title)) {
+            throw new ParseException(Log.TITLE_CONSTRAINTS);
+        }
+        return title;
+    }
+
+    public static String parseDescription(String description) throws ParseException { // TODO: 8/3/2022  refactor into Description object
+        return description; // no restrictions on description at the moment
+    }
+
+
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -111,6 +111,8 @@ public class ModelManager implements Model {
         addressBook.setPerson(target, editedPerson);
     }
 
+
+
     //=========== Filtered Person List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/person/Log.java
+++ b/src/main/java/seedu/address/model/person/Log.java
@@ -72,7 +72,7 @@ public class Log {
 
     @Override
     public String toString() {
-        return this.title + "\n" + this.description;
+        return this.title + "\n" + this.description + "\n\n";
     }
 
     @Override

--- a/src/main/java/seedu/address/model/person/Log.java
+++ b/src/main/java/seedu/address/model/person/Log.java
@@ -1,9 +1,9 @@
 package seedu.address.model.person;
 
-import java.util.Objects;
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
+
+import java.util.Objects;
 
 /**
  * Represents a note or log tied to a Person in the address book.

--- a/src/main/java/seedu/address/model/person/Log.java
+++ b/src/main/java/seedu/address/model/person/Log.java
@@ -1,0 +1,91 @@
+package seedu.address.model.person;
+
+import java.util.Objects;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+/**
+ * Represents a note or log tied to a Person in the address book.
+ * Guarantees: immutable; is valid as declared in {@link #isValidTitle(String)}
+ */
+public class Log {
+
+    // default values
+    public static final String DEFAULT_NO_DESCRIPTION = "";
+
+    // constraints
+    public static final int TITLE_LENGTH_CONSTRAINT = 50;
+    private static final String TITLE_CONSTRAINTS = "Titles of logs must satisfy:\n"
+            + "1. Not be trivial (i.e. not empty or contain only spaces\n"
+            + "2. Be at most " + Log.TITLE_LENGTH_CONSTRAINT + " characters long. "
+            + "This is because of display limitations.";
+
+    // immutable attributes
+    private final String title;
+    private final String description;
+
+
+    /**
+     * Constructs a Log object.
+     *
+     * @param title       Title of the log.
+     * @param description Description tied to the log. Can be null.
+     */
+    public Log(String title, String description) {
+        requireNonNull(title);
+        checkArgument(isValidTitle(title), Log.TITLE_CONSTRAINTS);
+        this.title = title;
+        this.description = Objects.requireNonNullElse(description, Log.DEFAULT_NO_DESCRIPTION);
+    }
+
+    /**
+     * Returns true if a given string is a valid title.
+     */
+    public static boolean isValidTitle(String title) {
+        requireNonNull(title);
+        return (title.length() > 0) // not empty string
+                && (title.split(" ").length > 0) // at least one non-space item
+                && (title.length() < Log.TITLE_LENGTH_CONSTRAINT); // within length limit
+    }
+
+    public String getDescription() {
+        requireNonNull(this.description);
+        return this.description;
+    }
+
+    public String getTitle() {
+        requireNonNull(this.title);
+        return this.title;
+    }
+
+    /**
+     * Returns true if other Log is considered the same as this Log.
+     * By convention, we consider two Logs the same if their titles are the same.
+     *
+     * @param other The other log.
+     * @return True if other log is considered the same.
+     */
+    public boolean isSameLog(Log other) {
+        return this.getTitle().equals(other.getTitle());
+    }
+
+    @Override
+    public String toString() {
+        return this.title + "\n" + this.description;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Log
+                && (this.getTitle().equals(((Log) other).getTitle())) //getters ensure non-null
+                && (this.getDescription().equals(((Log) other).getDescription())));
+    }
+
+    @Override
+    public int hashCode() {
+        return this.title.hashCode();
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/Log.java
+++ b/src/main/java/seedu/address/model/person/Log.java
@@ -16,7 +16,7 @@ public class Log {
 
     // constraints
     public static final int TITLE_LENGTH_CONSTRAINT = 50;
-    private static final String TITLE_CONSTRAINTS = "Titles of logs must satisfy:\n"
+    public static final String TITLE_CONSTRAINTS = "Titles of logs must satisfy:\n"
             + "1. Not be trivial (i.e. not empty or contain only spaces\n"
             + "2. Be at most " + Log.TITLE_LENGTH_CONSTRAINT + " characters long. "
             + "This is because of display limitations.";

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -63,6 +63,10 @@ public class Person {
         return this.logs.asUnmodifiableObservableList();
     }
 
+    public boolean containsLog(Log log) {
+        return this.logs.contains(log);
+    }
+
     /**
      * Returns true if both persons have the same name.
      * This defines a weaker notion of equality between two persons.

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,10 +2,7 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 
 import seedu.address.model.tag.Tag;
 
@@ -23,17 +20,19 @@ public class Person {
     // Data fields
     private final Address address;
     private final Set<Tag> tags = new HashSet<>();
+    private final UniqueLogList logs = new UniqueLogList();
 
     /**
      * Every field must be present and not null.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
+    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, List<Log> logs) {
+        requireAllNonNull(name, phone, email, address, tags, logs);
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         this.tags.addAll(tags);
+        this.logs.setLogs(logs);
     }
 
     public Name getName() {
@@ -58,6 +57,10 @@ public class Person {
      */
     public Set<Tag> getTags() {
         return Collections.unmodifiableSet(tags);
+    }
+
+    public List<Log> getLogs() {
+        return this.logs.asUnmodifiableObservableList();
     }
 
     /**
@@ -92,13 +95,14 @@ public class Person {
                 && otherPerson.getPhone().equals(getPhone())
                 && otherPerson.getEmail().equals(getEmail())
                 && otherPerson.getAddress().equals(getAddress())
-                && otherPerson.getTags().equals(getTags());
+                && otherPerson.getTags().equals(getTags())
+                && otherPerson.getLogs().equals(getLogs());
     }
 
     @Override
     public int hashCode() {
         // use this method for custom fields hashing instead of implementing your own
-        return Objects.hash(name, phone, email, address, tags);
+        return Objects.hash(name, phone, email, address, tags, logs);
     }
 
     @Override
@@ -116,6 +120,11 @@ public class Person {
         if (!tags.isEmpty()) {
             builder.append("; Tags: ");
             tags.forEach(builder::append);
+        }
+        List<Log> logs = this.getLogs();
+        if (!logs.isEmpty()) {
+            builder.append(": Logs: \n");
+            logs.forEach(builder::append);
         }
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,7 +2,11 @@ package seedu.address.model.person;
 
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.*;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 
 import seedu.address.model.tag.Tag;
 

--- a/src/main/java/seedu/address/model/person/UniqueLogList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLogList.java
@@ -88,4 +88,43 @@ public class UniqueLogList {
         }
     }
 
+    /**
+     * Replaces the contents of the list with all of {@code logs}.
+     * {@code logs} must not contain duplicate log.
+     */
+    public void setLogs(List<Log> logs) {
+        requireAllNonNull(logs);
+        if (!this.logsAreUnique(logs)) {
+            throw new DuplicateLogException();
+        }
+        this.internalList.setAll(logs);
+    }
+
+    /**
+     * Returns true if and only if {@code logs} contains only unique (by title) logs.
+     */
+    public boolean logsAreUnique(List<Log> logs) {
+        int n = logs.size();
+        for (int i = 0; i < n- 1; i++) { // iterate like N choose 2
+            for (int j = i + 1; j < n; j++) {
+                if (logs.get(i).isSameLog(logs.get(j))) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Returns the list of logs as an unmodifiable {@code ObservableList}.
+     */
+    public ObservableList<Log> asUnmodifiableObservableList() {
+        return this.internalUnmodifiableList;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.internalList.hashCode();
+    }
+
 }

--- a/src/main/java/seedu/address/model/person/UniqueLogList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLogList.java
@@ -3,7 +3,6 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-
 import java.util.List;
 
 import javafx.collections.FXCollections;

--- a/src/main/java/seedu/address/model/person/UniqueLogList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLogList.java
@@ -3,15 +3,13 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
-import java.util.Iterator;
+
 import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import seedu.address.model.person.exceptions.DuplicateLogException;
-import seedu.address.model.person.exceptions.DuplicatePersonException;
 import seedu.address.model.person.exceptions.LogNotFoundException;
-import seedu.address.model.person.exceptions.PersonNotFoundException;
 
 /**
  * A list of Logs that enforces the uniqueness between its elements and does not
@@ -28,7 +26,8 @@ import seedu.address.model.person.exceptions.PersonNotFoundException;
  */
 public class UniqueLogList {
 
-    private final ObservableList<Log> internalList = FXCollections.observableArrayList(); // observable list allows Java FX listeners to track changes
+    // observable list allows Java FX listeners to track changes
+    private final ObservableList<Log> internalList = FXCollections.observableArrayList();
     private final ObservableList<Log> internalUnmodifiableList =
             FXCollections.unmodifiableObservableList(internalList);
 
@@ -40,6 +39,10 @@ public class UniqueLogList {
         return this.internalList.stream().anyMatch(log::isSameLog);
     }
 
+    /**
+     * Returns true if the list contains a log that matches exactly the
+     * given {@code Log}. A stronger form of contains.
+     */
     public boolean containsExactly(Log log) {
         requireAllNonNull(log);
         return this.internalList.stream().anyMatch(log::equals);
@@ -105,7 +108,7 @@ public class UniqueLogList {
      */
     public boolean logsAreUnique(List<Log> logs) {
         int n = logs.size();
-        for (int i = 0; i < n- 1; i++) { // iterate like N choose 2
+        for (int i = 0; i < n - 1; i++) { // iterate like N choose 2
             for (int j = i + 1; j < n; j++) {
                 if (logs.get(i).isSameLog(logs.get(j))) {
                     return false;

--- a/src/main/java/seedu/address/model/person/UniqueLogList.java
+++ b/src/main/java/seedu/address/model/person/UniqueLogList.java
@@ -1,0 +1,91 @@
+package seedu.address.model.person;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.Iterator;
+import java.util.List;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import seedu.address.model.person.exceptions.DuplicateLogException;
+import seedu.address.model.person.exceptions.DuplicatePersonException;
+import seedu.address.model.person.exceptions.LogNotFoundException;
+import seedu.address.model.person.exceptions.PersonNotFoundException;
+
+/**
+ * A list of Logs that enforces the uniqueness between its elements and does not
+ * allow nulls.
+ *
+ * <p>A log is considered unique by comparing {@code Log#isSameLog(Log)}. As such, adding and updating
+ * of Logs uses Log#isSameLog(Log) for equality to ensure that the Log being added or updated is unique
+ * in terms of "identity" in the UniqueLogList.Deleting of Logs uses Log#equals(Object) for equality to ensure
+ * that the Log being deleted is exactly correct.
+ *
+ * <p>Supports a minimal set of list operations.
+ *
+ * @see Log#isSameLog(Log)
+ */
+public class UniqueLogList {
+
+    private final ObservableList<Log> internalList = FXCollections.observableArrayList(); // observable list allows Java FX listeners to track changes
+    private final ObservableList<Log> internalUnmodifiableList =
+            FXCollections.unmodifiableObservableList(internalList);
+
+    /**
+     * Returns true if the list contains an equivalent log as the given argument.
+     */
+    public boolean contains(Log log) {
+        requireAllNonNull(log);
+        return this.internalList.stream().anyMatch(log::isSameLog);
+    }
+
+    public boolean containsExactly(Log log) {
+        requireAllNonNull(log);
+        return this.internalList.stream().anyMatch(log::equals);
+    }
+
+    /**
+     * Adds a log to the list.
+     * An identical log must not already exist in the list.
+     */
+    public void addLog(Log log) {
+        requireNonNull(log);
+        if (this.contains(log)) {
+            throw new DuplicateLogException();
+        }
+        internalList.add(log);
+    }
+
+    /**
+     * Replaces the {@code target} in the list with the {@code editedLog}.
+     * The {@code target} log must exist in the list, and the identity of the {@code editedLog}
+     * must be different from all existing logs in the list.
+     */
+    public void setLog(Log targetLog, Log editedLog) {
+        requireAllNonNull(targetLog, editedLog);
+
+        if (!targetLog.isSameLog(editedLog) && this.contains(editedLog)) { // trying to insert something already inside
+            throw new DuplicateLogException();
+        }
+
+        int index = this.internalList.indexOf(targetLog);
+        if (index == -1) {
+            throw new LogNotFoundException();
+        }
+
+        this.internalList.set(index, editedLog);
+    }
+
+    /**
+     * Removes the equivalent log from the list.
+     * The log must exist in the list.
+     */
+    public void removeLog(Log toRemove) {
+        requireNonNull(toRemove);
+        if (!this.internalList.remove(toRemove)) {
+            throw new LogNotFoundException();
+        }
+    }
+
+}

--- a/src/main/java/seedu/address/model/person/exceptions/DuplicateLogException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/DuplicateLogException.java
@@ -1,0 +1,11 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation will result in duplicate Persons (Persons are considered duplicates if they have the same
+ * identity).
+ */
+public class DuplicateLogException extends RuntimeException {
+    public DuplicateLogException() {
+        super("Operation would result in duplicate logs");
+    }
+}

--- a/src/main/java/seedu/address/model/person/exceptions/LogNotFoundException.java
+++ b/src/main/java/seedu/address/model/person/exceptions/LogNotFoundException.java
@@ -1,0 +1,6 @@
+package seedu.address.model.person.exceptions;
+
+/**
+ * Signals that the operation is unable to find the specified log.
+ */
+public class LogNotFoundException extends RuntimeException {}

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -1,42 +1,43 @@
 package seedu.address.model.util;
 
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 
 /**
  * Contains utility methods for populating {@code AddressBook} with sample data.
  */
 public class SampleDataUtil {
+
+    public static final List<Log> EMPTY_LOG_LIST = new ArrayList<Log>();
+
     public static Person[] getSamplePersons() {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"),
-                getTagSet("friends")),
+                getTagSet("friends"), EMPTY_LOG_LIST),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"),
-                getTagSet("colleagues", "friends")),
+                getTagSet("colleagues", "friends"), EMPTY_LOG_LIST),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"),
-                getTagSet("neighbours")),
+                getTagSet("neighbours"), EMPTY_LOG_LIST),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"),
-                getTagSet("family")),
+                getTagSet("family"), EMPTY_LOG_LIST),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"),
-                getTagSet("classmates")),
+                getTagSet("classmates"), EMPTY_LOG_LIST),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"),
-                getTagSet("colleagues"))
+                getTagSet("colleagues"), EMPTY_LOG_LIST)
         };
     }
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -8,7 +8,12 @@ import java.util.stream.Collectors;
 
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Log;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedLog.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLog.java
@@ -1,0 +1,42 @@
+package seedu.address.storage;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+import seedu.address.commons.exceptions.IllegalValueException;
+import seedu.address.model.person.Log;
+
+
+/**
+ * Jackson-friendly version of {@link Log}
+ */
+public class JsonAdaptedLog {
+    private final String title;
+    private final String description;
+
+    /**
+     * Constructs a {@code JsonAdaptedLog} with the given {@code title} and {@code desccription}.
+     * Assumes that title and description are both valid and non-null.
+     */
+    @JsonCreator
+    public JsonAdaptedLog(@JsonProperty("title") String title, @JsonProperty("description") String description) {
+        this.title = title;
+        this.description = description;
+    }
+
+    /**
+     * Constructs a {@code JsonAdaptedLog} with the given {@code Log}.
+     */
+    public JsonAdaptedLog(Log log) {
+        this.title = log.getTitle();
+        this.description = log.getDescription();
+    }
+
+    public Log toModelType() throws IllegalValueException {
+        if (!Log.isValidTitle(this.title)) {
+            throw new IllegalValueException(Log.TITLE_CONSTRAINTS);
+        }
+        return new Log(this.title, this.description);
+    }
+}

--- a/src/main/java/seedu/address/storage/JsonAdaptedLog.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedLog.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Log;
@@ -33,6 +32,12 @@ public class JsonAdaptedLog {
         this.description = log.getDescription();
     }
 
+    /**
+     * Converts a {@code JsonAdoptedLog} to a {@code Log} object.
+     *
+     * @throws IllegalValueException if constructed {@code Log} contains
+     *                               illegal values.
+     */
     public Log toModelType() throws IllegalValueException {
         if (!Log.isValidTitle(this.title)) {
             throw new IllegalValueException(Log.TITLE_CONSTRAINTS);

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -10,7 +10,12 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.person.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Log;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
 import seedu.address.model.tag.Tag;
 
 /**

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -10,11 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -29,20 +25,25 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tagged = new ArrayList<>();
+    private final List<JsonAdaptedLog> logs = new ArrayList<>();
 
     /**
      * Constructs a {@code JsonAdaptedPerson} with the given person details.
      */
     @JsonCreator
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
-            @JsonProperty("email") String email, @JsonProperty("address") String address,
-            @JsonProperty("tagged") List<JsonAdaptedTag> tagged) {
+                             @JsonProperty("email") String email, @JsonProperty("address") String address,
+                             @JsonProperty("tagged") List<JsonAdaptedTag> tagged,
+                             @JsonProperty("logs") List<JsonAdaptedLog> logs) {
         this.name = name;
         this.phone = phone;
         this.email = email;
         this.address = address;
         if (tagged != null) {
             this.tagged.addAll(tagged);
+        }
+        if (logs != null) {
+            this.logs.addAll(logs);
         }
     }
 
@@ -57,6 +58,9 @@ class JsonAdaptedPerson {
         tagged.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
+        logs.addAll(source.getLogs().stream()
+                .map(JsonAdaptedLog::new)
+                .collect(Collectors.toList()));
     }
 
     /**
@@ -65,10 +69,6 @@ class JsonAdaptedPerson {
      * @throws IllegalValueException if there were any data constraints violated in the adapted person.
      */
     public Person toModelType() throws IllegalValueException {
-        final List<Tag> personTags = new ArrayList<>();
-        for (JsonAdaptedTag tag : tagged) {
-            personTags.add(tag.toModelType());
-        }
 
         if (name == null) {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName()));
@@ -102,8 +102,20 @@ class JsonAdaptedPerson {
         }
         final Address modelAddress = new Address(address);
 
+        final List<Tag> personTags = new ArrayList<>();
+        for (JsonAdaptedTag tag : tagged) {
+            personTags.add(tag.toModelType());
+        }
         final Set<Tag> modelTags = new HashSet<>(personTags);
-        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+
+
+        final List<Log> personLogs = new ArrayList<>();
+        for (JsonAdaptedLog log : logs) {
+            personLogs.add(log.toModelType());
+        }
+        final List<Log> modelLogs = personLogs;
+
+        return new Person(modelName, modelPhone, modelEmail, modelAddress, modelTags, modelLogs);
     }
 
 }

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,42 +5,95 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friends" ],
+    "logs" : [ ]
   }, {
     "name" : "Benson Meier",
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "tagged" : [ "owesMoney", "friends" ]
+    "tagged" : [ "owesMoney", "friends" ],
+    "logs" : [ ]
   }, {
     "name" : "Carl Kurz",
     "phone" : "95352563",
     "email" : "heinz@example.com",
     "address" : "wall street",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "logs" : [ ]
   }, {
     "name" : "Daniel Meier",
     "phone" : "87652533",
     "email" : "cornelia@example.com",
     "address" : "10th street",
-    "tagged" : [ "friends" ]
+    "tagged" : [ "friends" ],
+    "logs" : [ ]
   }, {
     "name" : "Elle Meyer",
     "phone" : "9482224",
     "email" : "werner@example.com",
     "address" : "michegan ave",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "logs" : [ ]
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
     "email" : "lydia@example.com",
     "address" : "little tokyo",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "logs" : [ ]
   }, {
     "name" : "George Best",
     "phone" : "9482442",
     "email" : "anna@example.com",
     "address" : "4th street",
-    "tagged" : [ ]
+    "tagged" : [ ],
+    "logs" : [ ]
+  }, {
+    "name" : "JAMES BOND",
+    "phone" : "83382178",
+    "email" : "jb@example.com",
+    "address" : "Singapore street",
+    "tagged" : [ ],
+    "logs" : [ {
+      "title" : "met in 2013",
+      "description" : null
+    } ]
+  }, {
+    "name" : "KAREN K",
+    "phone" : "99999999",
+    "email" : "kk@example.com",
+    "address" : "some street",
+    "tagged" : [ ],
+    "logs" : [ {
+      "title" : "favourite movies",
+      "description" : "1. Batman\n2. Superman\nSuper super into movies, can probably get some themed gift for birthday."
+    } ]
+  }, {
+    "name" : "Lauren Wong",
+    "phone" : "93829384",
+    "email" : "laurenwong@example.com",
+    "address" : "queen st.",
+    "tagged" : [ ],
+    "logs" : [ {
+      "title" : "birthday coming up",
+      "description" : "maybe get a card"
+    } ]
+  }, {
+    "name" : "Mavis Tan",
+    "phone" : "96382727",
+    "email" : "mavis.tan@example.com",
+    "address" : "king st.",
+    "tagged" : [ ],
+    "logs" : [  {
+      "title" : "met in 2013",
+      "description" : null
+    }, {
+      "title" : "birthday coming up",
+      "description" : "maybe get a card"
+    }, {
+      "title" : "favourite movies",
+      "description" : "1. Batman\n2. Superman\nSuper super into movies, can probably get some themed gift for birthday."
+    } ]
   } ]
 }

--- a/src/test/java/seedu/address/logic/commands/AddLogCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLogCommandTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for AddLogCommand.
+ */
+public class AddLogCommandTest {
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    // ===== UNIT TESTS =====
+    @Test
+    public void equals() {
+        // same values -> returns true
+
+        // same object -> returns true
+
+        // null -> returns false
+
+        // different types -> returns false
+
+        // different index -> returns false
+
+        // different descriptor -> returns false
+    }
+
+    // ===== INTEGRATION TESTS WITH MODEL =====
+    @Test
+    public void execute_validIInput_success() {
+        // only title
+
+
+        // title and description
+
+    }
+
+    @Test
+    public void execute_noChanges_success() {
+
+    }
+
+    @Test
+    public void execute_duplicateLog_failure() {
+
+    }
+
+    @Test
+    public void execute_invalidInput_failure() {
+        // ===== FILTERED LIST =====
+        // invalid index
+
+        // missing index
+
+        // invalid title
+
+        // missing title
+
+
+        // ===== UNFILTERED LIST =====
+        // invalid index
+
+        // missing index
+
+        // invalid title
+
+        // missing title
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddLogCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLogCommandTest.java
@@ -1,74 +1,261 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
 
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
+import seedu.address.model.person.Log;
+import seedu.address.model.person.Person;
+import seedu.address.testutil.PersonBuilder;
 
 /**
  * Contains integration tests (interaction with the Model) and unit tests for AddLogCommand.
  */
 public class AddLogCommandTest {
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_TITLE = Log.TITLE_CONSTRAINTS;
+    private static final String MESSAGE_INVALID_INDEX = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 
     // ===== UNIT TESTS =====
     @Test
     public void equals() {
+        AddLogCommand command;
+        AddLogCommand other;
+        AddLogCommand.AddLogDescriptor descriptor;
+        AddLogCommand.AddLogDescriptor otherDescriptor;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        Index otherIndex = INDEX_SECOND_PERSON;
+        String title = "some title";
+        String otherTitle = "some other title";
+
         // same values -> returns true
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        command = new AddLogCommand(targetIndex, descriptor);
+        other = new AddLogCommand(targetIndex, descriptor);
+        assertEquals(command, other);
 
         // same object -> returns true
+        assertEquals(command, command);
 
         // null -> returns false
+        assertNotEquals(command, null);
 
         // different types -> returns false
+        assertNotEquals(command, "some other type");
 
         // different index -> returns false
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        command = new AddLogCommand(targetIndex, descriptor);
+        other = new AddLogCommand(otherIndex, descriptor);
+        assertNotEquals(command, other);
 
         // different descriptor -> returns false
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        otherDescriptor = new AddLogCommand.AddLogDescriptor();
+        otherDescriptor.setNewTitle(otherTitle);
+        command = new AddLogCommand(targetIndex, descriptor);
+        other = new AddLogCommand(targetIndex, otherDescriptor);
+        assertNotEquals(command, other);
     }
 
-    // ===== INTEGRATION TESTS WITH MODEL =====
+    /* ===== INTEGRATION TESTS WITH MODEL =====
+    Integration tests with Model component. Note that we do tests for both filtered and unfiltered lists
+    as these states control what the user sees, but regardless the changes apply to the true underlying
+    data state of the model.
+     */
     @Test
-    public void execute_validIInput_success() {
-        // only title
+    public void execute_validIInput_unfilteredList_success() {
 
+        String title = VALID_LOG_TITLE;
+        String description = VALID_LOG_DESCRIPTION;
+        String expectedMessage = AddLogCommand.MESSAGE_ADD_LOG_SUCCESS;
+        AddLogCommand command;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        Log log;
+        Person basePerson;
+        Person addedLogPerson;
+        Model expectedModel;
+        AddLogCommand.AddLogDescriptor descriptor;
+        Model model;
+
+        // only title
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        log = new Log(title, null);
+        expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        basePerson = expectedModel.getFilteredPersonList().get(targetIndex.getZeroBased());
+        addedLogPerson = new PersonBuilder(basePerson).withLogs(log).build();
+        expectedModel.setPerson(basePerson, addedLogPerson);
+
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        command = new AddLogCommand(targetIndex, descriptor);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
 
         // title and description
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        log = new Log(title, description);
+        expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        basePerson = expectedModel.getFilteredPersonList().get(targetIndex.getZeroBased());
+        addedLogPerson = new PersonBuilder(basePerson).withLogs(log).build();
+        expectedModel.setPerson(basePerson, addedLogPerson);
+
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        descriptor.setNewDescription(description);
+        command = new AddLogCommand(targetIndex, descriptor);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
 
     }
 
     @Test
-    public void execute_noChanges_success() {
+    public void execute_validIInput_filteredList_success() {
+
+        String title = VALID_LOG_TITLE;
+        String description = VALID_LOG_DESCRIPTION;
+        String expectedMessage = AddLogCommand.MESSAGE_ADD_LOG_SUCCESS;
+        AddLogCommand command;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        Log log;
+        Person basePerson;
+        Person addedLogPerson;
+        Model expectedModel;
+        AddLogCommand.AddLogDescriptor descriptor;
+        Model model;
+
+        // only title
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        log = new Log(title, null);
+        showPersonAtIndex(model, INDEX_FIRST_PERSON); // apply filter
+
+        expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        basePerson = expectedModel.getFilteredPersonList().get(targetIndex.getZeroBased());
+        addedLogPerson = new PersonBuilder(basePerson).withLogs(log).build();
+        expectedModel.setPerson(basePerson, addedLogPerson);
+
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        command = new AddLogCommand(targetIndex, descriptor);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+
+        // title and description
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        log = new Log(title, description);
+        showPersonAtIndex(model, INDEX_FIRST_PERSON); // apply filter
+
+        expectedModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        basePerson = expectedModel.getFilteredPersonList().get(targetIndex.getZeroBased());
+        addedLogPerson = new PersonBuilder(basePerson).withLogs(log).build();
+        expectedModel.setPerson(basePerson, addedLogPerson);
+
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        descriptor.setNewDescription(description);
+        command = new AddLogCommand(targetIndex, descriptor);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
 
     }
 
     @Test
     public void execute_duplicateLog_failure() {
 
+        String title = VALID_LOG_TITLE;
+        Log log = new Log(title, null);
+        Model testModel;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        AddLogCommand.AddLogDescriptor descriptor;
+        AddLogCommand command;
+        Model model;
+        Person withLogPerson;
+
+        // ===== UNFILTERED LIST =====
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+
+        // add log into list
+        testModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        withLogPerson = new PersonBuilder().withLogs(log).build(); // build person with log
+
+        testModel.setPerson((model.getFilteredPersonList().get(targetIndex.getZeroBased())), withLogPerson); // add him in
+
+        // try to add again
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        command = new AddLogCommand(targetIndex, descriptor);
+        assertCommandFailure(command, testModel, AddLogCommand.MESSAGE_DUPLICATE_LOG);
+
+        // ===== FILTERED LIST =====
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        showPersonAtIndex(model, INDEX_FIRST_PERSON); // apply filter
+
+        // add log into list
+        testModel = new ModelManager(new AddressBook(model.getAddressBook()), new UserPrefs());
+        withLogPerson = new PersonBuilder().withLogs(log).build(); // build person with log
+        testModel.setPerson((model.getFilteredPersonList().get(targetIndex.getZeroBased())), withLogPerson); // add him in
+
+        // try to add again
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        command = new AddLogCommand(targetIndex, descriptor);
+        assertCommandFailure(command, testModel, AddLogCommand.MESSAGE_DUPLICATE_LOG);
     }
 
     @Test
-    public void execute_invalidInput_failure() {
-        // ===== FILTERED LIST =====
-        // invalid index
+    public void execute_invalidInput_unfilteredList_failure() {
 
-        // missing index
+        String title = VALID_LOG_TITLE;
+        String invalidTitle = "";
+        AddLogCommand command;
+        Index targetIndex = INDEX_FIRST_PERSON;
+        Index outOfBoundIndex;
+        AddLogCommand.AddLogDescriptor descriptor;
+        Model model;
 
-        // invalid title
+        // ===== INVALID INDEX =====
 
-        // missing title
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        showPersonAtIndex(model, INDEX_FIRST_PERSON); // apply filter
 
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        command = new AddLogCommand(outOfBoundIndex, descriptor);
+        assertCommandFailure(command, model, MESSAGE_INVALID_INDEX);
 
-        // ===== UNFILTERED LIST =====
-        // invalid index
+        // ===== INVALID TITLE =====
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        showPersonAtIndex(model, INDEX_FIRST_PERSON); // apply filter
 
-        // missing index
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(invalidTitle);
+        command = new AddLogCommand(targetIndex, descriptor);
+        System.out.println(descriptor);
+        assertCommandFailure(command, model, MESSAGE_INVALID_TITLE);
 
-        // invalid title
+        // ===== MISSING TITLE =====
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        showPersonAtIndex(model, INDEX_FIRST_PERSON); // apply filter
 
-        // missing title
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        command = new AddLogCommand(targetIndex, descriptor);
+        assertCommandFailure(command, model, MESSAGE_INVALID_FORMAT);
     }
 }
+

--- a/src/test/java/seedu/address/logic/commands/AddLogDescriptorTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddLogDescriptorTest.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class AddLogDescriptorTest {
+
+    @Test
+    public void equals() {
+        AddLogCommand.AddLogDescriptor descriptor;
+        AddLogCommand.AddLogDescriptor other;
+        String title = "some title";
+        String differentTitle = "other title";
+        String description = "some description";
+        String differentDescription = "some other description";
+
+        // same object -> returns true
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        assertEquals(descriptor, descriptor);
+
+        // same title -> returns true
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        other = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        other.setNewTitle(title);
+        assertEquals(descriptor, other);
+
+        // same title and description -> returns true
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        other = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        descriptor.setNewDescription(description);
+        other.setNewTitle(title);
+        other.setNewDescription(description);
+        assertEquals(descriptor, other);
+
+        // null -> returns false
+        assertNotEquals(descriptor, null);
+
+        // different types -> returns false
+        assertNotEquals(descriptor, "string object");
+
+        // different title same desc -> returns true
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        other = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        descriptor.setNewDescription(description);
+        other.setNewTitle(differentTitle);
+        other.setNewDescription(description);
+        assertNotEquals(descriptor, other);
+
+        // same title different desc -> returns false
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        other = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(title);
+        descriptor.setNewDescription(description);
+        other.setNewTitle(title);
+        other.setNewDescription(differentDescription);
+        assertNotEquals(descriptor, other);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -34,6 +34,8 @@ public class CommandTestUtil {
     public static final String VALID_TAG_FRIEND = "friend";
     public static final String VALID_LOG_TITLE = "some valid title";
     public static final String VALID_LOG_TITLE_PRECEDING_SPACE = " still a valid title";
+    public static final String VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED = "still a valid title";
+
     public static final String VALID_LOG_DESCRIPTION = "some description!";
     public static final String VALID_LOG_DESCRIPTION_OTHER = "some other description!";
 
@@ -49,6 +51,7 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String LOG_TITLE_DESC = " " + PREFIX_TITLE + VALID_LOG_TITLE;
     public static final String LOG_TITLE_DESC_PRECEDING_SPACE = " " + PREFIX_TITLE + VALID_LOG_TITLE_PRECEDING_SPACE;
+    public static final String LOG_TITLE_DESC_PRECEDING_SPACE_TRIMMED = " " + PREFIX_TITLE + VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED;
     public static final String LOG_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + VALID_LOG_DESCRIPTION;
     public static final String LOG_DESCRIPTION_DIFFERENT_DESC = " " + PREFIX_DESCRIPTION + VALID_LOG_DESCRIPTION_OTHER;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -2,7 +2,13 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.CliSyntax.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -51,7 +57,6 @@ public class CommandTestUtil {
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
     public static final String LOG_TITLE_DESC = " " + PREFIX_TITLE + VALID_LOG_TITLE;
     public static final String LOG_TITLE_DESC_PRECEDING_SPACE = " " + PREFIX_TITLE + VALID_LOG_TITLE_PRECEDING_SPACE;
-    public static final String LOG_TITLE_DESC_PRECEDING_SPACE_TRIMMED = " " + PREFIX_TITLE + VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED;
     public static final String LOG_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + VALID_LOG_DESCRIPTION;
     public static final String LOG_DESCRIPTION_DIFFERENT_DESC = " " + PREFIX_DESCRIPTION + VALID_LOG_DESCRIPTION_OTHER;
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -2,11 +2,7 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CliSyntax.*;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import java.util.ArrayList;
@@ -36,6 +32,10 @@ public class CommandTestUtil {
     public static final String VALID_ADDRESS_BOB = "Block 123, Bobby Street 3";
     public static final String VALID_TAG_HUSBAND = "husband";
     public static final String VALID_TAG_FRIEND = "friend";
+    public static final String VALID_LOG_TITLE = "some valid title";
+    public static final String VALID_LOG_TITLE_PRECEDING_SPACE = " still a valid title";
+    public static final String VALID_LOG_DESCRIPTION = "some description!";
+    public static final String VALID_LOG_DESCRIPTION_OTHER = "some other description!";
 
     public static final String NAME_DESC_AMY = " " + PREFIX_NAME + VALID_NAME_AMY;
     public static final String NAME_DESC_BOB = " " + PREFIX_NAME + VALID_NAME_BOB;
@@ -47,12 +47,20 @@ public class CommandTestUtil {
     public static final String ADDRESS_DESC_BOB = " " + PREFIX_ADDRESS + VALID_ADDRESS_BOB;
     public static final String TAG_DESC_FRIEND = " " + PREFIX_TAG + VALID_TAG_FRIEND;
     public static final String TAG_DESC_HUSBAND = " " + PREFIX_TAG + VALID_TAG_HUSBAND;
+    public static final String LOG_TITLE_DESC = " " + PREFIX_TITLE + VALID_LOG_TITLE;
+    public static final String LOG_TITLE_DESC_PRECEDING_SPACE = " " + PREFIX_TITLE + VALID_LOG_TITLE_PRECEDING_SPACE;
+    public static final String LOG_DESCRIPTION_DESC = " " + PREFIX_DESCRIPTION + VALID_LOG_DESCRIPTION;
+    public static final String LOG_DESCRIPTION_DIFFERENT_DESC = " " + PREFIX_DESCRIPTION + VALID_LOG_DESCRIPTION_OTHER;
+
 
     public static final String INVALID_NAME_DESC = " " + PREFIX_NAME + "James&"; // '&' not allowed in names
     public static final String INVALID_PHONE_DESC = " " + PREFIX_PHONE + "911a"; // 'a' not allowed in phones
     public static final String INVALID_EMAIL_DESC = " " + PREFIX_EMAIL + "bob!yahoo"; // missing '@' symbol
     public static final String INVALID_ADDRESS_DESC = " " + PREFIX_ADDRESS; // empty string not allowed for addresses
     public static final String INVALID_TAG_DESC = " " + PREFIX_TAG + "hubby*"; // '*' not allowed in tags
+    public static final String INVALID_LOG_TITLE_EMPTY_STRING_DESC = " " + PREFIX_TITLE + "";
+    public static final String INVALID_LOG_TITLE_ONLY_SPACES_DESC = " " + PREFIX_TITLE + "     ";
+    public static final String INVALID_LOG_TITLE_TOO_LONG_DESC = " " + PREFIX_TITLE + "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
 
     public static final String PREAMBLE_WHITESPACE = "\t  \r  \n";
     public static final String PREAMBLE_NON_EMPTY = "NonEmptyPreamble";

--- a/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
@@ -6,7 +6,6 @@ import seedu.address.logic.commands.AddLogCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.model.person.Log;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.AddLogCommandParser.MESSAGE_INVALID_FORMAT;
@@ -40,8 +39,6 @@ public class AddLogCommandParserTest {
         // no index and no title specified
         args = LOG_DESCRIPTION_DESC;
         assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
-
-
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
@@ -1,0 +1,157 @@
+package seedu.address.logic.parser;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddLogCommand;
+import seedu.address.logic.commands.Command;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+public class AddLogCommandParserTest {
+
+    private AddLogCommandParser parser = new AddLogCommandParser();
+    private static final String MESSAGE_INVALID_FORMAT =
+            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE);
+
+    @Test
+    public void parse_missingParts_failure() {
+
+        String args;
+
+        // no index specified
+        args = LOG_TITLE_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        args = LOG_TITLE_DESC +  LOG_DESCRIPTION_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+        // no title specified
+        args = "1" + LOG_DESCRIPTION_DESC; // with description
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        args = "1";
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+        // no index and no title specified
+        args = LOG_DESCRIPTION_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+
+    }
+
+    @Test
+    public void parse_invalidPreamble_failure() {
+        /*
+        Preamble (i.e. argument before any /PREFIX) used as index. User could throw garbage input.
+         */
+
+        String args;
+
+        // negative index
+        args = "-5" + LOG_TITLE_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+        // zero index, since list should be 1-indexed
+        args = "0" + LOG_TITLE_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+        // invalid arguments being parsed as preamble
+        args = "somegarbagepreamble" + LOG_TITLE_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+    }
+
+    @Test
+    public void parse_invaildPrefixesPresent_failure() {
+        String args;
+
+        // random garbage input
+        args = "1 i/ string";
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        args = "1 i/string /g something else";
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidValue_failure() {
+
+        String args;
+
+        // invalid titles
+        args = "1" + INVALID_LOG_TITLE_EMPTY_STRING_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        args = "1" + INVALID_LOG_TITLE_ONLY_SPACES_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        args = "1" + INVALID_LOG_TITLE_TOO_LONG_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+        // prefixes without actual arguments
+        args = "1" + " " + PREFIX_TITLE;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        args = "1" + " " + PREFIX_TITLE + " " + PREFIX_DESCRIPTION;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+    }
+
+    @Test
+    public void parse_allFieldsValid_success() {
+        Command expectedCommand;
+        String args;
+        AddLogCommand.AddLogDescriptor descriptor;
+        Index targetIndex = INDEX_FIRST_PERSON;
+
+        // valid title
+        args = targetIndex.getOneBased() + LOG_TITLE_DESC;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE);
+        expectedCommand = new AddLogCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+
+        // another valid title
+        args = targetIndex.getOneBased() + VALID_LOG_TITLE_PRECEDING_SPACE;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE);
+        expectedCommand = new AddLogCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+
+        // valid title and description
+        args = targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE);
+        descriptor.setNewDescription(VALID_LOG_DESCRIPTION);
+        expectedCommand = new AddLogCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleRepeatedFields_acceptsLast() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String args = targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_TITLE_DESC_PRECEDING_SPACE
+                + LOG_DESCRIPTION_DESC + LOG_DESCRIPTION_DIFFERENT_DESC;
+        AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE);
+        descriptor.setNewDescription(VALID_LOG_DESCRIPTION_OTHER);
+        AddLogCommand expectedCommand = new AddLogCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+    }
+
+    @Test
+    public void parse_multipleInvalidFieldsButLastValid_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        String args = targetIndex.getOneBased() + INVALID_LOG_TITLE_EMPTY_STRING_DESC + LOG_TITLE_DESC_PRECEDING_SPACE
+                + LOG_DESCRIPTION_DESC + LOG_DESCRIPTION_DIFFERENT_DESC;
+        AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE);
+        descriptor.setNewDescription(VALID_LOG_DESCRIPTION_OTHER);
+        AddLogCommand expectedCommand = new AddLogCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+    }
+
+
+
+
+}

--- a/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
@@ -1,23 +1,34 @@
 package seedu.address.logic.parser;
 
-import org.junit.jupiter.api.Test;
-import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.AddLogCommand;
-import seedu.address.logic.commands.Command;
-import seedu.address.model.person.Log;
-
-import static seedu.address.logic.commands.CommandTestUtil.*;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOG_TITLE_EMPTY_STRING_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOG_TITLE_ONLY_SPACES_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOG_TITLE_TOO_LONG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LOG_DESCRIPTION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LOG_DESCRIPTION_DIFFERENT_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LOG_TITLE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LOG_TITLE_DESC_PRECEDING_SPACE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_DESCRIPTION_OTHER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_TITLE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED;
 import static seedu.address.logic.parser.AddLogCommandParser.MESSAGE_INVALID_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.AddLogCommand;
+import seedu.address.logic.commands.Command;
+import seedu.address.model.person.Log;
+
 public class AddLogCommandParserTest {
 
-    private AddLogCommandParser parser = new AddLogCommandParser();
     private static final String MESSAGE_INVALID_TITLE = Log.TITLE_CONSTRAINTS;
+    private final AddLogCommandParser parser = new AddLogCommandParser();
 
     @Test
     public void parse_missingParts_failure() {
@@ -27,7 +38,7 @@ public class AddLogCommandParserTest {
         // no index specified
         args = LOG_TITLE_DESC;
         assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
-        args = LOG_TITLE_DESC +  LOG_DESCRIPTION_DESC;
+        args = LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
         assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
 
         // no title specified
@@ -148,8 +159,6 @@ public class AddLogCommandParserTest {
         AddLogCommand expectedCommand = new AddLogCommand(targetIndex, descriptor);
         assertParseSuccess(parser, args, expectedCommand);
     }
-
-
 
 
 }

--- a/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
@@ -4,10 +4,12 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddLogCommand;
 import seedu.address.logic.commands.Command;
+import seedu.address.model.person.Log;
 
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.AddLogCommandParser.MESSAGE_INVALID_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -16,8 +18,7 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 public class AddLogCommandParserTest {
 
     private AddLogCommandParser parser = new AddLogCommandParser();
-    private static final String MESSAGE_INVALID_FORMAT =
-            String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE);
+    private static final String MESSAGE_INVALID_TITLE = Log.TITLE_CONSTRAINTS;
 
     @Test
     public void parse_missingParts_failure() {
@@ -83,17 +84,17 @@ public class AddLogCommandParserTest {
 
         // invalid titles
         args = "1" + INVALID_LOG_TITLE_EMPTY_STRING_DESC;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
         args = "1" + INVALID_LOG_TITLE_ONLY_SPACES_DESC;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
         args = "1" + INVALID_LOG_TITLE_TOO_LONG_DESC;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
 
         // prefixes without actual arguments
         args = "1" + " " + PREFIX_TITLE;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
         args = "1" + " " + PREFIX_TITLE + " " + PREFIX_DESCRIPTION;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
 
     }
 
@@ -112,9 +113,9 @@ public class AddLogCommandParserTest {
         assertParseSuccess(parser, args, expectedCommand);
 
         // another valid title
-        args = targetIndex.getOneBased() + VALID_LOG_TITLE_PRECEDING_SPACE;
+        args = targetIndex.getOneBased() + LOG_TITLE_DESC_PRECEDING_SPACE;
         descriptor = new AddLogCommand.AddLogDescriptor();
-        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE);
+        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED);
         expectedCommand = new AddLogCommand(targetIndex, descriptor);
         assertParseSuccess(parser, args, expectedCommand);
 
@@ -133,7 +134,7 @@ public class AddLogCommandParserTest {
         String args = targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_TITLE_DESC_PRECEDING_SPACE
                 + LOG_DESCRIPTION_DESC + LOG_DESCRIPTION_DIFFERENT_DESC;
         AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
-        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE);
+        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED);
         descriptor.setNewDescription(VALID_LOG_DESCRIPTION_OTHER);
         AddLogCommand expectedCommand = new AddLogCommand(targetIndex, descriptor);
         assertParseSuccess(parser, args, expectedCommand);
@@ -145,7 +146,7 @@ public class AddLogCommandParserTest {
         String args = targetIndex.getOneBased() + INVALID_LOG_TITLE_EMPTY_STRING_DESC + LOG_TITLE_DESC_PRECEDING_SPACE
                 + LOG_DESCRIPTION_DESC + LOG_DESCRIPTION_DIFFERENT_DESC;
         AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
-        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE);
+        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED);
         descriptor.setNewDescription(VALID_LOG_DESCRIPTION_OTHER);
         AddLogCommand expectedCommand = new AddLogCommand(targetIndex, descriptor);
         assertParseSuccess(parser, args, expectedCommand);

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -1,9 +1,13 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.LOG_DESCRIPTION_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.LOG_TITLE_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_DESCRIPTION;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_TITLE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -14,8 +18,16 @@ import java.util.stream.Collectors;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.index.Index;
-import seedu.address.logic.commands.*;
+import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AddLogCommand;
+import seedu.address.logic.commands.ClearCommand;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
+import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -87,7 +99,8 @@ public class AddressBookParserTest {
         Index targetIndex = INDEX_FIRST_PERSON;
 
         // command
-        String validAddLogCommand = AddLogCommand.COMMAND_WORD + " " + targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+        String validAddLogCommand = AddLogCommand.COMMAND_WORD + " "
+                + targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
 
         // expected command
         AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
@@ -102,7 +115,7 @@ public class AddressBookParserTest {
     @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-                -> parser.parseCommand(""));
+            -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -1,9 +1,9 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -13,15 +13,9 @@ import java.util.stream.Collectors;
 
 import org.junit.jupiter.api.Test;
 
-import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.ClearCommand;
-import seedu.address.logic.commands.DeleteCommand;
-import seedu.address.logic.commands.EditCommand;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.*;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
-import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
-import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
@@ -89,9 +83,26 @@ public class AddressBookParserTest {
     }
 
     @Test
+    public void parseCommand_addLog() throws Exception {
+        Index targetIndex = INDEX_FIRST_PERSON;
+
+        // command
+        String validAddLogCommand = AddLogCommand.COMMAND_WORD + " " + targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+
+        // expected command
+        AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE);
+        descriptor.setNewDescription(VALID_LOG_DESCRIPTION);
+        AddLogCommand command = new AddLogCommand(INDEX_FIRST_PERSON, descriptor);
+
+        assertEquals(command, parser.parseCommand(validAddLogCommand));
+        assertTrue(parser.parseCommand(validAddLogCommand) instanceof AddLogCommand);
+    }
+
+    @Test
     public void parseCommand_unrecognisedInput_throwsParseException() {
         assertThrows(ParseException.class, String.format(MESSAGE_INVALID_COMMAND_FORMAT, HelpCommand.MESSAGE_USAGE), ()
-            -> parser.parseCommand(""));
+                -> parser.parseCommand(""));
     }
 
     @Test

--- a/src/test/java/seedu/address/model/person/LogTest.java
+++ b/src/test/java/seedu/address/model/person/LogTest.java
@@ -21,9 +21,6 @@ public class LogTest {
         for (int i = 0; i < Log.TITLE_LENGTH_CONSTRAINT - 1; i++) {
             longTitle += "c";
         }
-        System.out.println(longTitle.length());
-        System.out.println(Log.TITLE_LENGTH_CONSTRAINT);
-        System.out.println(longTitle.length() < Log.TITLE_LENGTH_CONSTRAINT);
         assertTrue(Log.isValidTitle(longTitle)); // exactly as many characters
         assertFalse(Log.isValidTitle(longTitle + "c")); // >limit characters
 

--- a/src/test/java/seedu/address/model/person/LogTest.java
+++ b/src/test/java/seedu/address/model/person/LogTest.java
@@ -1,0 +1,73 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class LogTest {
+
+    @Test
+    public void isValidLogTitle() {
+        // null
+        assertThrows(NullPointerException.class, () -> Log.isValidTitle(null));
+
+        // blank title
+        assertFalse(Log.isValidTitle("")); // empty string
+        assertFalse(Log.isValidTitle("              ")); // spaces only
+
+        // valid length?
+        String longTitle = "";
+        for (int i = 0; i < Log.TITLE_LENGTH_CONSTRAINT - 1; i++) {
+            longTitle += "c";
+        }
+        System.out.println(longTitle.length());
+        System.out.println(Log.TITLE_LENGTH_CONSTRAINT);
+        System.out.println(longTitle.length() < Log.TITLE_LENGTH_CONSTRAINT);
+        assertTrue(Log.isValidTitle(longTitle)); // exactly as many characters
+        assertFalse(Log.isValidTitle(longTitle + "c")); // >limit characters
+
+        // valid
+        assertTrue(Log.isValidTitle(" peter jack")); // start with space
+        assertTrue(Log.isValidTitle("12345")); // numbers only
+        assertTrue(Log.isValidTitle("peter the 2nd")); // alphanumeric characters
+        assertTrue(Log.isValidTitle("Capital Tan")); // with capital letters
+        assertTrue(Log.isValidTitle("David Roger Jackson Ray Jr 2nd")); // long name
+        assertTrue(Log.isValidTitle("`~!@#$%^&*()_-+={[}]|\\:;\"\'<,>.?/")); // random characters
+    }
+
+    @Test
+    public void constructor_null_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> new Log(null, null));
+    }
+
+    @Test
+    public void constructor_invalidTitle_throwsIllegalArgumentException() {
+
+        assertThrows(IllegalArgumentException.class, () -> new Log("", null)); // empty
+        assertThrows(IllegalArgumentException.class, () -> new Log("      ", null)); // spaces only
+
+        String longTitle = "";
+        for (int i = 0; i < Log.TITLE_LENGTH_CONSTRAINT; i++) {
+            longTitle += "c";
+        }
+        final String tooLongTitle = longTitle;
+        assertThrows(IllegalArgumentException.class, () -> new Log(tooLongTitle, null)); // too many characters
+
+    }
+
+    @Test
+    public void constructor_noDescription_defaultDescription() {
+        String title = "title";
+        assertEquals(new Log(title, Log.DEFAULT_NO_DESCRIPTION), new Log(title, null));
+    }
+
+    @Test
+    public void constructor_haveDescription_givenDescription() {
+        String title = "title";
+        String description = "description";
+        Log testLog = new Log(title, description);
+        assertEquals(testLog.getDescription(), description);
+        assertEquals(testLog.getTitle(), title);
+    }
+}

--- a/src/test/java/seedu/address/model/person/LogTest.java
+++ b/src/test/java/seedu/address/model/person/LogTest.java
@@ -1,6 +1,8 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -14,6 +14,7 @@ import static seedu.address.testutil.TypicalPersons.BOB;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalLogs;
 
 public class PersonTest {
 
@@ -87,5 +88,12 @@ public class PersonTest {
         // different tags -> returns false
         editedAlice = new PersonBuilder(ALICE).withTags(VALID_TAG_HUSBAND).build();
         assertFalse(ALICE.equals(editedAlice));
+
+        // different logs (titles && description must match) -> returns false
+        editedAlice = new PersonBuilder(ALICE).withLogs(TypicalLogs.getTypicalLogs()).build();
+        assertFalse(ALICE.equals(editedAlice));
+        Person editedAliceWithDifferentDescriptions = new PersonBuilder(ALICE)
+                .withLogs(TypicalLogs.getIdenticalButDifferentTypicalLogs()).build();
+
     }
 }

--- a/src/test/java/seedu/address/model/person/UniqueLogListTest.java
+++ b/src/test/java/seedu/address/model/person/UniqueLogListTest.java
@@ -1,0 +1,148 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+import seedu.address.model.person.exceptions.DuplicateLogException;
+import seedu.address.model.person.exceptions.LogNotFoundException;
+
+import static seedu.address.testutil.Assert.assertThrows;
+
+public class UniqueLogListTest {
+
+
+    @Test
+    public void contains_null_throwsNullPointerException() {
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        assertThrows(NullPointerException.class, () -> uniqueLogList.contains(null));
+    }
+
+    @Test
+    public void contains_logNotInList_returnsFalse() {
+        Log toFind = new Log("title", null);
+        UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty, test add separately
+        assertFalse(uniqueLogList.contains(toFind));
+    }
+
+    @Test
+    public void contains_logInList_returnsTrue() {
+        Log toAdd = new Log("title", null);
+        Log identical = new Log("title", "some description");
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        uniqueLogList.addLog(toAdd);
+        assertTrue(uniqueLogList.contains(identical));
+    }
+
+    @Test
+    public void containsExactly_null_throwsNullPointerException() {
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        assertThrows(NullPointerException.class, () -> uniqueLogList.containsExactly(null));
+    }
+
+    @Test
+    public void containsExactly_logNotInList_returnsFalse() {
+        Log toFind = new Log("title", null);
+        UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty, test add separately
+        assertFalse(uniqueLogList.containsExactly(toFind));
+    }
+
+    @Test
+    public void containsExactly_logInList_returnsTrue() {
+        Log toAdd = new Log("title", "some description");
+        Log identical = new Log("title", "some description");
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        uniqueLogList.addLog(toAdd);
+        assertTrue(uniqueLogList.containsExactly(identical));
+    }
+
+    @Test
+    public void add_nullLog_throwsNullPointerException() {
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        assertThrows(NullPointerException.class, () -> uniqueLogList.addLog(null));
+    }
+
+
+    @Test
+    public void add_duplicateLog_throwsDuplicateLogException() {
+        Log toAdd = new Log("title", null);
+        Log similarLog = new Log("title", "some description"); // similar == same title
+        Log anotherSimilarLog = new Log("title", "some other description");
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        uniqueLogList.addLog(toAdd);
+        assertThrows(DuplicateLogException.class, () -> uniqueLogList.addLog(similarLog));
+        assertThrows(DuplicateLogException.class, () -> uniqueLogList.addLog(anotherSimilarLog));
+    }
+
+    @Test
+    public void setLog_targetLogNotInside_throwsLogNotFoundException() {
+        Log target = new Log("target", null);
+        Log editedLog = new Log("target", "now added description");
+        Log notTargetLog = new Log("not target", null);
+
+        // target not in empty list
+        UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty
+        assertThrows(LogNotFoundException.class, () -> uniqueLogList.setLog(target, editedLog));
+
+        // target not in list
+        uniqueLogList.addLog(notTargetLog); // contains non-target log
+        assertThrows(LogNotFoundException.class, () -> uniqueLogList.setLog(target, editedLog));
+    }
+
+
+    @Test
+    public void setLog_validEdit_contains_returnsTrue() {
+        // target is inside, and edited log are identical
+        Log target = new Log("target", "description");
+        Log editedLog = new Log("target", "description");
+        assertTrue(target.equals(editedLog)); // identical logs
+        UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty
+        uniqueLogList.addLog(target);
+        assertTrue(uniqueLogList.contains(target));
+        uniqueLogList.setLog(target, editedLog);
+        assertTrue(uniqueLogList.containsExactly(target)); // no change semantically, since setter sets identical thing
+
+        // target is inside, and edited log same title but different description
+        Log actuallyEditedLog = new Log("target", "some different description");
+        Log actuallyEditedLogToFind = new Log("target", "some different description");
+        uniqueLogList.setLog(target, actuallyEditedLog);
+        assertTrue(uniqueLogList.contains(target)); // same title still inside
+        assertFalse(uniqueLogList.containsExactly(target)); // semantically different
+        assertTrue(uniqueLogList.containsExactly(actuallyEditedLogToFind));
+    }
+
+    @Test
+    public void removeLog_null_throwsNullPointerException() {
+        UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty
+        assertThrows(NullPointerException.class, () -> uniqueLogList.removeLog(null));
+    }
+
+    @Test
+    public void removeLog_logNotInside_throwsLogNotFoundException() {
+        // empty log
+        Log target = new Log("target", "description");
+        UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty
+        assertThrows(LogNotFoundException.class, () -> uniqueLogList.removeLog(target));
+
+        // not inside
+        Log nonTarget = new Log("not target", "description");
+        uniqueLogList.addLog(nonTarget);
+        assertTrue(uniqueLogList.contains(nonTarget)); // not empty
+        assertThrows(LogNotFoundException.class, () -> uniqueLogList.removeLog(target));
+
+    }
+
+    @Test
+    public void removeLog_valid_contains_returnsFalse() {
+
+        Log target = new Log("not target", "description");
+        UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty
+        uniqueLogList.addLog(target);
+
+        Log toRemove = new Log("not target", "description"); // exact match to remove
+        assertTrue(uniqueLogList.containsExactly(target)); // target is inside
+        uniqueLogList.removeLog(toRemove);
+        assertFalse(uniqueLogList.contains(target)); // removed successfully
+    }
+}

--- a/src/test/java/seedu/address/model/person/UniqueLogListTest.java
+++ b/src/test/java/seedu/address/model/person/UniqueLogListTest.java
@@ -1,14 +1,13 @@
 package seedu.address.model.person;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
+
 import seedu.address.model.person.exceptions.DuplicateLogException;
 import seedu.address.model.person.exceptions.LogNotFoundException;
-
-import static seedu.address.testutil.Assert.assertThrows;
 
 public class UniqueLogListTest {
 
@@ -92,7 +91,7 @@ public class UniqueLogListTest {
 
 
     @Test
-    public void setLog_validEdit_contains_returnsTrue() {
+    public void setLog_validEditContains_returnsTrue() {
         // target is inside, and edited log are identical
         Log target = new Log("target", "description");
         Log editedLog = new Log("target", "description");
@@ -134,7 +133,7 @@ public class UniqueLogListTest {
     }
 
     @Test
-    public void removeLog_valid_contains_returnsFalse() {
+    public void removeLog_validContains_returnsFalse() {
 
         Log target = new Log("not target", "description");
         UniqueLogList uniqueLogList = new UniqueLogList(); // initially empty

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -15,7 +15,10 @@ import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.testutil.PersonBuilder;
+import seedu.address.testutil.TypicalLogs;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -31,24 +34,36 @@ public class JsonAdaptedPersonTest {
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
+    private static final List<JsonAdaptedLog> VALID_LOGS = TypicalLogs.getTypicalLogs().stream()
+            .map(JsonAdaptedLog::new)
+            .collect(Collectors.toList());
 
     @Test
     public void toModelType_validPersonDetails_returnsPerson() throws Exception {
+
         JsonAdaptedPerson person = new JsonAdaptedPerson(BENSON);
         assertEquals(BENSON, person.toModelType());
     }
 
     @Test
+    public void toModelType_validPersonDetailsWithLogs_returnsPerson() throws Exception {
+
+        Person bensonWithLogs = new PersonBuilder(BENSON).withLogs(TypicalLogs.getTypicalLogs()).build();
+        JsonAdaptedPerson jsonPerson = new JsonAdaptedPerson(bensonWithLogs);
+        assertEquals(bensonWithLogs, jsonPerson.toModelType());
+    }
+
+    @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LOGS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LOGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -56,14 +71,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LOGS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LOGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -71,14 +86,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LOGS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_LOGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -86,14 +101,14 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_LOGS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
-        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS);
+        JsonAdaptedPerson person = new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_LOGS);
         String expectedMessage = String.format(MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,8 +118,7 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_LOGS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
-
 }

--- a/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
+++ b/src/test/java/seedu/address/testutil/EditPersonDescriptorBuilder.java
@@ -81,6 +81,8 @@ public class EditPersonDescriptorBuilder {
         return this;
     }
 
+
+
     public EditPersonDescriptor build() {
         return descriptor;
     }

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -5,7 +5,13 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import seedu.address.model.person.*;
+import seedu.address.model.person.Address;
+import seedu.address.model.person.Email;
+import seedu.address.model.person.Log;
+import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.Phone;
+import seedu.address.model.person.UniqueLogList;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -90,6 +96,9 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Log} of the {@code Person} that we are building.
+     */
     public PersonBuilder withLogs(Log ... logs) {
         UniqueLogList uniqueLogList = new UniqueLogList();
         uniqueLogList.setLogs(List.of(logs));
@@ -97,14 +106,15 @@ public class PersonBuilder {
         return this;
     }
 
+    /**
+     * Sets the {@code Log} of the {@code Person} that we are building.
+     */
     public PersonBuilder withLogs(List<Log> logs) {
         UniqueLogList uniqueLogList = new UniqueLogList();
         uniqueLogList.setLogs(logs);
         this.logs = uniqueLogList.asUnmodifiableObservableList();
         return this;
     }
-
-
 
     public Person build() {
         return new Person(name, phone, email, address, tags, logs);

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -1,13 +1,11 @@
 package seedu.address.testutil;
 
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
-import seedu.address.model.person.Address;
-import seedu.address.model.person.Email;
-import seedu.address.model.person.Name;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
+import seedu.address.model.person.*;
 import seedu.address.model.tag.Tag;
 import seedu.address.model.util.SampleDataUtil;
 
@@ -26,6 +24,7 @@ public class PersonBuilder {
     private Email email;
     private Address address;
     private Set<Tag> tags;
+    private List<Log> logs;
 
     /**
      * Creates a {@code PersonBuilder} with the default details.
@@ -36,6 +35,7 @@ public class PersonBuilder {
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
         tags = new HashSet<>();
+        logs = new ArrayList<>();
     }
 
     /**
@@ -47,6 +47,7 @@ public class PersonBuilder {
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
         tags = new HashSet<>(personToCopy.getTags());
+        logs = personToCopy.getLogs();
     }
 
     /**
@@ -89,8 +90,24 @@ public class PersonBuilder {
         return this;
     }
 
+    public PersonBuilder withLogs(Log ... logs) {
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        uniqueLogList.setLogs(List.of(logs));
+        this.logs = uniqueLogList.asUnmodifiableObservableList();
+        return this;
+    }
+
+    public PersonBuilder withLogs(List<Log> logs) {
+        UniqueLogList uniqueLogList = new UniqueLogList();
+        uniqueLogList.setLogs(logs);
+        this.logs = uniqueLogList.asUnmodifiableObservableList();
+        return this;
+    }
+
+
+
     public Person build() {
-        return new Person(name, phone, email, address, tags);
+        return new Person(name, phone, email, address, tags, logs);
     }
 
 }

--- a/src/test/java/seedu/address/testutil/TypicalLogs.java
+++ b/src/test/java/seedu/address/testutil/TypicalLogs.java
@@ -1,10 +1,10 @@
 package seedu.address.testutil;
 
-import seedu.address.model.person.Log;
-
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+
+import seedu.address.model.person.Log;
 
 public class TypicalLogs {
 

--- a/src/test/java/seedu/address/testutil/TypicalLogs.java
+++ b/src/test/java/seedu/address/testutil/TypicalLogs.java
@@ -1,0 +1,34 @@
+package seedu.address.testutil;
+
+import seedu.address.model.person.Log;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+public class TypicalLogs {
+
+    public static final Log LOG_NO_DESCRIPTION = new Log("met in 2013", null);
+    public static final Log SHORT_LOG = new Log("birthday coming up", "maybe get a card");
+    public static final Log LONG_LOG = new Log("favourite movies",
+            "1. Batman\n"
+                    + "2. Superman\n"
+                    + "Super super into movies, can probably get some themed gift for birthday.");
+    public static final Log SHORT_LOG_DIFFERENT_DESC = new Log("birthday coming up",
+            "maybe get a card" + "difference");
+    public static final Log LONG_LOG_DIFFERENT_DESC = new Log("favourite movies",
+            "1. Batman\n"
+                    + "2. Superman\n"
+                    + "Super super into movies, can probably get some themed gift for birthday."
+                    + "\nDifference");
+
+    private TypicalLogs() {} // prevents instantiation
+
+    public static List<Log> getTypicalLogs() {
+        return new ArrayList<>(Arrays.asList(LOG_NO_DESCRIPTION, SHORT_LOG, LONG_LOG));
+    }
+
+    public static List<Log> getIdenticalButDifferentTypicalLogs() {
+        return new ArrayList<>(Arrays.asList(LOG_NO_DESCRIPTION, SHORT_LOG_DIFFERENT_DESC, LONG_LOG_DIFFERENT_DESC));
+    }
+}

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -48,6 +48,23 @@ public class TypicalPersons {
     public static final Person IDA = new PersonBuilder().withName("Ida Mueller").withPhone("8482131")
             .withEmail("hans@example.com").withAddress("chicago ave").build();
 
+    // With logs
+    public static final Person JAMES = new PersonBuilder().withName("JAMES BOND").withPhone("83382178")
+            .withEmail("jb@example.com").withAddress("Singapore street")
+            .withLogs(TypicalLogs.LOG_NO_DESCRIPTION).build(); // single log
+
+    public static final Person KAREN = new PersonBuilder().withName("KAREN K").withPhone("99999999")
+            .withEmail("kk@example.com").withAddress("some street")
+            .withLogs(TypicalLogs.LONG_LOG).build(); // single log
+
+    public static final Person LAUREN = new PersonBuilder().withName("Luaren Wong").withPhone("93829384")
+            .withEmail("laurenwong@example.com").withAddress("queen st.")
+            .withLogs(TypicalLogs.SHORT_LOG).build(); // single log
+
+    public static final Person MAVIS = new PersonBuilder().withName("Mavis Tan").withPhone("96382727")
+            .withEmail("mavis.tan@example.com").withAddress("king st.")
+            .withLogs(TypicalLogs.getTypicalLogs()).build(); // single log
+
     // Manually added - Person's details found in {@code CommandTestUtil}
     public static final Person AMY = new PersonBuilder().withName(VALID_NAME_AMY).withPhone(VALID_PHONE_AMY)
             .withEmail(VALID_EMAIL_AMY).withAddress(VALID_ADDRESS_AMY).withTags(VALID_TAG_FRIEND).build();

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -57,7 +57,7 @@ public class TypicalPersons {
             .withEmail("kk@example.com").withAddress("some street")
             .withLogs(TypicalLogs.LONG_LOG).build(); // single log
 
-    public static final Person LAUREN = new PersonBuilder().withName("Luaren Wong").withPhone("93829384")
+    public static final Person LAUREN = new PersonBuilder().withName("Lauren Wong").withPhone("93829384")
             .withEmail("laurenwong@example.com").withAddress("queen st.")
             .withLogs(TypicalLogs.SHORT_LOG).build(); // single log
 
@@ -88,6 +88,8 @@ public class TypicalPersons {
     }
 
     public static List<Person> getTypicalPersons() {
-        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE, FIONA, GEORGE));
+        return new ArrayList<>(Arrays.asList(ALICE, BENSON, CARL, DANIEL, ELLE,
+                FIONA, GEORGE, JAMES, KAREN, LAUREN, MAVIS
+        ));
     }
 }


### PR DESCRIPTION
Fixes #54 

# Summary of changes:
1. Added `Log` and `UniqueLogList` classes, with `UniqueLogList` encapsulated by a `Person` and containing `Logs`.
2. Updated storage component to support storage of `Logs` in JSON format, by adding `JsonAdaptedLog` class and updating other relevant storage classes.
3. Implemented `AddLogCommand`, `AddLogCommandParser` classes to support `addlog` feature, and updated relevant associated classes.
4. Wrote and updated unit and integration tests and test cases. 
5. Updated `UserGuide.md` to reflect changed formatting of `addlog` command format.

# Main design points to take note: 

## 1. `Logs`
* Logs are considered identical if they have the same title, and a `UniqueLogList` cannot have two identical `Log` objects.
* Logs are considered equal if they have the same title AND description.
* The default description for a `Log` if no description is provided is an empty string.

## 2. `UniqueLogList`
The unique log list is intended to be pointed to by a Person object, such that each person has a list of logs. In this PR, basic list functionalities of add, set, remove, contains have been added.

## 3. `Person` class now contains `Log` objects using a `UniqueLogList`
Self explanatory. Encapsulation allows for clean and safe usage, creation and deletion of `Log` objects.

## 4. `AddLogCommand` and `AddLogDescriptor` helper class

To support the `addlog` feature, three classes have been implemented:
* `AddLogCommand` class
* `AddLogCommand.AddLogDescriptor` class
* `AddLogCommandParser` class

The inclusion of the three classes integrates nicely into the existing `Command` interface framework. A notable design choice was to use a static inner`AddLogCommand.AddLogDescriptor` class, and the rationale was to follow the analogous design in the `EditCommand` class, since it was easily extendible and helped with cleaner encapsulation.

At a high level, how it works is as follows:
1. `AddLogCommandParser` parses an input string --> `TITLE` and `DESCRIPTION` fields are wrapped by a `AddLogDescriptor` class, and then wrapped by a `AddLogCommand` object. 
2. when `.execute()` is called, the `AddLogDescriptor` object creates a list of `Log` objects that contains previous logs contained by the `Person`, as well as the new `Log`.
3. A new `Person` object is created with this new list and all the other old, unchanged details, and passed to `Model` to handle writing to the data state. 
