### PR TITLE
V1.2b deletefriendbyindex

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,7 +8,9 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INDEX_IS_NOT_NON_ZERO_UNSIGNED_INTEGER = "Index is not a non-zero unsigned integer";
     public static final String MESSAGE_INVALID_PERSON_NAME = "The name provided is not a valid name!";
+    public static final String MESSAGE_PERSON_DOES_NOT_EXIST = "This friend does not exist in Amigos";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
 
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -5,12 +5,15 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Description;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Log;
 import seedu.address.model.person.Name;
@@ -27,10 +30,12 @@ public class DeleteCommand extends Command {
     public static final String COMMAND_WORD = "deletefriend";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Deletes the friend identified by name.\n"
+            + ": Deletes the friend identified by index or name.\n"
             + "Parameters: "
-            + PREFIX_NAME + "NAME (must be name of a friend who exists in Amigos)\n"
-            + "Example: " + COMMAND_WORD + " " + PREFIX_NAME + "John Doe";
+            + PREFIX_NAME + "NAME (name of a friend who exists in Amigos) OR "
+            + "INDEX (a positive integer)\n"
+            + "Example 1: " + COMMAND_WORD + " " + PREFIX_NAME + "John Doe\n"
+            + "Example 2: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted friend: %1$s";
 
@@ -39,45 +44,77 @@ public class DeleteCommand extends Command {
     private static final Phone dummyPhone = new Phone("12345678");
     private static final Email dummyEmail = new Email("dummyemail@gmail.com");
     private static final Address dummyAddress = new Address("Dummy Address");
+    private static final Description dummyDescription = new Description("Dummy Description");
 
     private final Name nameOfPersonToDelete;
+    private final Index targetIndex;
+    private final boolean isDeletionByIndex;
 
-
+    /**
+     * Constructs a DeleteCommand for deletion by name
+     * @param nameOfPersonToDelete The name of the person to be deleted
+     */
     public DeleteCommand(Name nameOfPersonToDelete) {
         this.nameOfPersonToDelete = nameOfPersonToDelete;
+        this.targetIndex = Index.fromOneBased(1); //a dummy value
+        this.isDeletionByIndex = false;
     }
+
+    /**
+     * Constructs a DeleteCommand for deletion by index
+     * @param targetIndex The index of the person to be deleted on the filtered list on GUI
+     */
+    public DeleteCommand(Index targetIndex) {
+        this.nameOfPersonToDelete = new Name("name"); //a dummy value
+        this.targetIndex = targetIndex;
+        this.isDeletionByIndex = true;
+    }
+
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
 
         requireNonNull(model);
 
-        Person personWithNameToDelete = new Person(nameOfPersonToDelete, dummyPhone,
-                dummyEmail, dummyAddress, new HashSet<Tag>(), new ArrayList<Log>());
-
-        if (!model.hasPerson(personWithNameToDelete)) { //model.hasPerson considers 2 Persons with same name
-            //to be the same Person
-            throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
-        }
-
-        ObservableList<Person> personList = model.getAddressBook().getPersonList();
-
-        final Person[] personToDelete = new Person[1];
-
-        personList.forEach((person) -> {
-            if (person.isSamePerson(personWithNameToDelete)) {
-                personToDelete[0] = person;
-                model.deletePerson(person);
+        if (isDeletionByIndex) { //deletion by index
+            List<Person> lastShownList = model.getFilteredPersonList();
+            if (targetIndex.getZeroBased() >= lastShownList.size()) {
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
             }
-        });
+            Person personToDelete = lastShownList.get(targetIndex.getZeroBased());
+            model.deletePerson(personToDelete);
+            return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
 
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete[0]));
+        } else { //deletion by name
+            Person personWithNameToDelete = new Person(nameOfPersonToDelete, dummyPhone,
+                    dummyEmail, dummyAddress, dummyDescription, new HashSet<Tag>(), new ArrayList<Log>());
+
+            if (!model.hasPerson(personWithNameToDelete)) { //model.hasPerson considers 2 Persons with same name
+                //to be the same Person
+                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
+            }
+            ObservableList<Person> personList = model.getAddressBook().getPersonList();
+            Person personToDelete = personWithNameToDelete; //dummy person
+
+            for (Person personFromList : personList) {
+                if (personFromList.isSamePerson(personWithNameToDelete)) {
+                    personToDelete = new Person(personFromList.getName(),
+                            personFromList.getPhone(), personFromList.getEmail(),
+                            personFromList.getAddress(), personFromList.getDescription(),
+                            personFromList.getTags(), personFromList.getLogs());
+                    model.deletePerson(personFromList);
+                    break;
+                }
+            }
+            return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
+        }
     }
-
     @Override
     public boolean equals(Object other) {
+        System.out.println(this.isDeletionByIndex);
         return other == this // short circuit if same object
                 || (other instanceof DeleteCommand // instanceof handles nulls
-                && nameOfPersonToDelete.equals(((DeleteCommand) other).nameOfPersonToDelete)); // state check
+                && nameOfPersonToDelete.equals(((DeleteCommand) other).nameOfPersonToDelete) //state checl
+                && targetIndex.equals(((DeleteCommand) other).targetIndex));
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -76,6 +76,7 @@ public class DeleteCommand extends Command {
                 //to be the same Person
                 throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
             }
+            //todo : make this more oop
             ObservableList<Person> personList = model.getAddressBook().getPersonList();
             Person personToDelete = personWithNameToDelete; //dummy person
 

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -13,6 +13,7 @@ import seedu.address.model.Model;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 
+
 /**
  * Deletes a person identified using it's displayed index from the address book.
  */
@@ -36,20 +37,22 @@ public class DeleteCommand extends Command {
 
     /**
      * Constructs a DeleteCommand for deletion by name
+     *
      * @param nameOfPersonToDelete The name of the person to be deleted
      */
     public DeleteCommand(Name nameOfPersonToDelete) {
         this.nameOfPersonToDelete = nameOfPersonToDelete;
-        this.targetIndex = Index.fromOneBased(1); //a dummy value
+        this.targetIndex = null;
         this.isDeletionByIndex = false;
     }
 
     /**
      * Constructs a DeleteCommand for deletion by index
+     *
      * @param targetIndex The index of the person to be deleted on the filtered list on GUI
      */
     public DeleteCommand(Index targetIndex) {
-        this.nameOfPersonToDelete = new Name("name"); //a dummy value
+        this.nameOfPersonToDelete = null;
         this.targetIndex = targetIndex;
         this.isDeletionByIndex = true;
     }
@@ -74,7 +77,7 @@ public class DeleteCommand extends Command {
 
             if (!model.hasPerson(personWithNameToDelete)) { //model.hasPerson considers 2 Persons with same name
                 //to be the same Person
-                throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
+                throw new CommandException(Messages.MESSAGE_PERSON_DOES_NOT_EXIST);
             }
             //todo : make this more oop
             ObservableList<Person> personList = model.getAddressBook().getPersonList();
@@ -93,11 +96,19 @@ public class DeleteCommand extends Command {
             return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, personToDelete));
         }
     }
+
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                || (other instanceof DeleteCommand // instanceof handles nulls
-                && nameOfPersonToDelete.equals(((DeleteCommand) other).nameOfPersonToDelete) //state checl
-                && targetIndex.equals(((DeleteCommand) other).targetIndex));
+        if (other == this) {
+            return true;
+        } else if (other instanceof DeleteCommand) {
+            DeleteCommand otherDeleteCommand = (DeleteCommand) other;
+            if (otherDeleteCommand.isDeletionByIndex && this.isDeletionByIndex) {
+                return otherDeleteCommand.targetIndex.equals(this.targetIndex);
+            } else if (!otherDeleteCommand.isDeletionByIndex && !this.isDeletionByIndex) {
+                return otherDeleteCommand.nameOfPersonToDelete.equals(this.nameOfPersonToDelete);
+            }
+        }
+        return false;
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -104,8 +104,12 @@ public class DeleteCommand extends Command {
         } else if (other instanceof DeleteCommand) {
             DeleteCommand otherDeleteCommand = (DeleteCommand) other;
             if (otherDeleteCommand.isDeletionByIndex && this.isDeletionByIndex) {
+                //assertion to ensure that if it is deletion by index, then targetIndex will not be null
+                assert(otherDeleteCommand.targetIndex != null && this.targetIndex != null);
                 return otherDeleteCommand.targetIndex.equals(this.targetIndex);
             } else if (!otherDeleteCommand.isDeletionByIndex && !this.isDeletionByIndex) {
+                //assertion to ensure that if it is deletion by name, then name will not be null
+                assert(otherDeleteCommand.nameOfPersonToDelete != null && this.nameOfPersonToDelete != null);
                 return otherDeleteCommand.nameOfPersonToDelete.equals(this.nameOfPersonToDelete);
             }
         }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -3,8 +3,10 @@ package seedu.address.logic.parser;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
+import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Name;
@@ -21,16 +23,30 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      * @throws ParseException if the user input does not conform the expected format
      */
     public DeleteCommand parse(String args) throws ParseException {
-        ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_NAME);
 
-        if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
-                || !argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        Pattern p = Pattern.compile("-?\\d+(\\.\\d+)?"); //Regex to match all numeric Strings
+        boolean isDeletionByIndex = isNumeric(p, args);
+        System.out.println(isDeletionByIndex);
+
+        if (isDeletionByIndex) { //deletion by index
+            try {
+                Index index = ParserUtil.parseIndex(args);
+                return new DeleteCommand(index);
+            } catch (ParseException pe) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+            }
+        } else { //deletion by name
+            ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);
+
+            if (!arePrefixesPresent(argMultimap, PREFIX_NAME)
+                    || !argMultimap.getPreamble().isEmpty()) {
+                throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+            }
+
+            Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
+            return new DeleteCommand(name);
         }
-
-        Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
-        return new DeleteCommand(name);
     }
 
     /**
@@ -39,6 +55,17 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
         return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+
+    /**
+     * Checks whether the argument entered by user is numeric
+     * @param p Regex to check if the argument entered by user is numeric
+     * @param strNum Argument entered by user.
+     * @return True if the argument entered by user is numeric
+     */
+    private static boolean isNumeric(Pattern p, String strNum) {
+        String strNumTrimmed = strNum.trim();
+        return p.matcher(strNumTrimmed).matches();
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INDEX_IS_NOT_NON_ZERO_UNSIGNED_INTEGER;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
@@ -32,8 +33,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
                 Index index = ParserUtil.parseIndex(args);
                 return new DeleteCommand(index);
             } catch (ParseException pe) {
-                throw new ParseException(
-                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE), pe);
+                throw new ParseException(MESSAGE_INDEX_IS_NOT_NON_ZERO_UNSIGNED_INTEGER);
             }
         } else { //deletion by name
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME);

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -24,9 +24,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
      */
     public DeleteCommand parse(String args) throws ParseException {
 
-        Pattern p = Pattern.compile("-?\\d+(\\.\\d+)?"); //Regex to match all numeric Strings
+        Pattern p = Pattern.compile("^-?\\d*\\.{0,1}\\d+$"); //Regex to match all numeric Strings
         boolean isDeletionByIndex = isNumeric(p, args);
-        System.out.println(isDeletionByIndex);
 
         if (isDeletionByIndex) { //deletion by index
             try {

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_NAME;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.commons.core.Messages.MESSAGE_PERSON_DOES_NOT_EXIST;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
@@ -61,10 +61,8 @@ public class LogicManagerTest {
 
     @Test
     public void execute_invalidExecutionError_throwsCommandException() {
-        //System.out.println(model.getAddressBook().getPersonList().size());
-        //personList is empty
         String deleteCommand = "deletefriend n/fakename";
-        assertCommandException(deleteCommand, MESSAGE_INVALID_PERSON_NAME);
+        assertCommandException(deleteCommand, MESSAGE_PERSON_DOES_NOT_EXIST);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,8 +1,8 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.commons.core.Messages.MESSAGE_PERSON_DOES_NOT_EXIST;
+import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.EMAIL_DESC_AMY;
 import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -2,12 +2,17 @@ package seedu.address.logic.commands;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showPersonAtIndex;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
@@ -35,18 +40,73 @@ public class DeleteCommandTest {
         assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
     }
 
+    @Test
+    public void execute_validIndexUnfilteredList_success() {
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+
+        ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredList_success() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
+        DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_PERSON_SUCCESS, personToDelete);
+
+        Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+        expectedModel.deletePerson(personToDelete);
+        showNoPerson(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_invalidIndexFilteredList_throwsCommandException() {
+        showPersonAtIndex(model, INDEX_FIRST_PERSON);
+
+        Index outOfBoundIndex = INDEX_SECOND_PERSON;
+        // ensures that outOfBoundIndex is still in bounds of address book list
+        assertTrue(outOfBoundIndex.getZeroBased() < model.getAddressBook().getPersonList().size());
+
+        DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
+    }
+
 
     @Test
     public void equals() {
         DeleteCommand deleteFirstCommand = new DeleteCommand(new Name("Sprigatito"));
         DeleteCommand deleteSecondCommand = new DeleteCommand(new Name("Quaxly"));
+        DeleteCommand deleteThirdCommand = new DeleteCommand(INDEX_FIRST_PERSON);
+        DeleteCommand deleteFourthCommand = new DeleteCommand(INDEX_SECOND_PERSON);
 
         // same object -> returns true
         assertTrue(deleteFirstCommand.equals(deleteFirstCommand));
+        assertTrue(deleteThirdCommand.equals(deleteThirdCommand));
 
         // same values -> returns true
         DeleteCommand deleteFirstCommandCopy = new DeleteCommand(new Name("Sprigatito"));
         assertTrue(deleteFirstCommand.equals(deleteFirstCommandCopy));
+
+        DeleteCommand deleteThirdCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
+        assertTrue(deleteThirdCommandCopy.equals(deleteThirdCommandCopy));
 
         // different types -> returns false
         assertFalse(deleteFirstCommand.equals(1));
@@ -56,6 +116,9 @@ public class DeleteCommandTest {
 
         // different person -> returns false
         assertFalse(deleteFirstCommand.equals(deleteSecondCommand));
+
+        //different index -> returns false
+        assertFalse(deleteThirdCommand.equals(deleteFourthCommand));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -116,6 +116,10 @@ public class DeleteCommandTest {
         DeleteCommand deleteThirdCommandCopy = new DeleteCommand(INDEX_FIRST_PERSON);
         assertTrue(deleteThirdCommandCopy.equals(deleteThirdCommandCopy));
 
+        //different types of deletion -> returns false
+        assertFalse(new DeleteCommand(INDEX_FIRST_PERSON).equals(new DeleteCommand(model.getFilteredPersonList()
+                .get(INDEX_FIRST_PERSON.getZeroBased()).getName())));
+
         // different types -> returns false
         assertFalse(deleteFirstCommand.equals(1));
 

--- a/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteCommandTest.java
@@ -41,6 +41,14 @@ public class DeleteCommandTest {
     }
 
     @Test
+    public void execute_deleteInvalidName_throwsCommandException() {
+        //Tommy Ang does not exist in the sample model that is used for testing here
+        Person personToDelete = new Person(new Name("Tommy Ang"));
+        DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getName());
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_PERSON_DOES_NOT_EXIST);
+    }
+
+    @Test
     public void execute_validIndexUnfilteredList_success() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteCommand deleteCommand = new DeleteCommand(INDEX_FIRST_PERSON);
@@ -53,7 +61,7 @@ public class DeleteCommandTest {
     }
 
     @Test
-    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+    public void execute_invalidPositiveIndexUnfilteredList_throwsCommandException() {
         Index outOfBoundIndex = Index.fromOneBased(model.getFilteredPersonList().size() + 1);
         DeleteCommand deleteCommand = new DeleteCommand(outOfBoundIndex);
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -48,9 +48,16 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_deletefriend() throws Exception {
+    public void parseCommandByName_deletefriend() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand("deletefriend n/Dummy Name");
         assertEquals(new DeleteCommand(new Name("Dummy Name")), command);
+    }
+
+    @Test
+    public void parseCommandByIndex_deletefriend() throws Exception {
+        DeleteCommand command = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_WORD + " "
+            + INDEX_FIRST_PERSON.getOneBased());
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -28,12 +28,17 @@ public class DeleteCommandParserTest {
     private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
-    public void parse_validArgs_returnsDeleteCommand() {
+    public void parse_validArgsName_returnsDeleteCommand() {
         Person personToDelete = model.getFilteredPersonList().get(INDEX_FIRST_PERSON.getZeroBased());
         Name name = personToDelete.getName();
         DeleteCommand deleteCommand = new DeleteCommand(personToDelete.getName());
 
         assertParseSuccess(parser, " n/" + name.fullName, deleteCommand);
+    }
+
+    @Test
+    public void parse_validArgsIndex_returnsDeleteCommand() {
+        assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -67,6 +67,7 @@ public class DeleteCommandParserTest {
     @Test
     public void parse_noArgs_throwsParseException() {
         assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "   ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
 
 }

--- a/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/DeleteCommandParserTest.java
@@ -1,5 +1,6 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.Messages.MESSAGE_INDEX_IS_NOT_NON_ZERO_UNSIGNED_INTEGER;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -37,12 +38,35 @@ public class DeleteCommandParserTest {
     }
 
     @Test
+    public void parse_noNameGiven_throwsParseException() {
+        assertParseFailure(parser, " n/", Name.MESSAGE_CONSTRAINTS);
+    }
+
+
+    @Test
+    public void parse_invalidArgsName_throwsParseException() {
+        assertParseFailure(parser, " n/" + "!@", Name.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
     public void parse_validArgsIndex_returnsDeleteCommand() {
         assertParseSuccess(parser, "1", new DeleteCommand(INDEX_FIRST_PERSON));
     }
 
     @Test
+    public void parse_invalidIndex_throwsParseException() {
+        assertParseFailure(parser, "-1", MESSAGE_INDEX_IS_NOT_NON_ZERO_UNSIGNED_INTEGER);
+    }
+
+    @Test
     public void parse_invalidArgs_throwsParseException() {
         assertParseFailure(parser, "a", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+        assertParseFailure(parser, "/n", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
     }
+
+    @Test
+    public void parse_noArgs_throwsParseException() {
+        assertParseFailure(parser, "", String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteCommand.MESSAGE_USAGE));
+    }
+
 }


### PR DESCRIPTION
Allow users to delete a friend by either index or name, based on their preference. More experienced users may choose to delete a friend by index instead of name to increase efficiency.

Summary of changes done:
- Overloaded the constructor of delete command so that Delete command can be constructed with either a Name or an Index.
- Added a boolean field isDeletionByIndex, which will be instantiated as True/False based on which Delete command constructor is used.
- Updated DeleteCommandParser to be able to parse both text for Name and numbers for Index.
- Updated test cases correspondingly to test both Delete command by index and Delete command by friend.

fixes #90 