### PR TITLE
Fix `addlog` command bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Description;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Log;
 import seedu.address.model.person.Name;
@@ -88,9 +89,10 @@ public class AddLogCommand extends Command {
         Phone phone = personToEdit.getPhone();
         Email email = personToEdit.getEmail();
         Address address = personToEdit.getAddress();
+        Description description = personToEdit.getDescription();
         Set<Tag> tags = personToEdit.getTags();
         List<Log> updatedLogs = addLogDescriptor.getLogsAfterAdd(personToEdit); // main logic encompassed here
-        return new Person(name, phone, email, address, tags, updatedLogs);
+        return new Person(name, phone, email, address, description, tags, updatedLogs);
     }
 
     @Override


### PR DESCRIPTION
Fixes #83 

Current implementation of `addlog` accidentally resets the description
of the `Person` object due to wrong use of an overloaded constructor.

Simple fix to call the correct constructor.