### PR TITLE
Add name-based `addlog`

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -52,6 +52,8 @@ Amigos is a desktop application to help tech-savvy university students manage th
 * Extraneous parameters for commands that do not take in parameters (such as `showfriends`, `showevents` and `exit`) will be ignored.<br>
   e.g. if the command specifies `showfriends 123`, it will be interpreted as `showfriends`.
 
+* Arguments connected by a `?` are exclusively-or - i.e. only one or the other can be provided. 
+  e.g. in `addlog INDEX ? n/NAME`, either `INDEX` or `NAME` must be provided, but not both.
 </div>
 
 ## Friend Management
@@ -131,7 +133,7 @@ Amigos provides functionality to manage logs, which are essentially detailed not
 
 Adds a log to an existing friend at the specified `INDEX` in Amigos.
 The `INDEX` refers to the index number shown in the displayed person's list.
-Format: `addlog INDEX ? n/NAME t/[TITLE] d/[DESCRIPTION]`
+Format: `addlog INDEX ? n/NAME ttl/[TITLE] d/[DESCRIPTION]`
 
 * Exactly one of `INDEX` or the `NAME` fields is compulsory.
 * If the `TITLE` argument is provided, then the `DESCRIPTON` argument is optional.
@@ -139,8 +141,8 @@ Format: `addlog INDEX ? n/NAME t/[TITLE] d/[DESCRIPTION]`
   pop up will prompt the user to key in the title and longer-form text as the description.
 
 Examples:
-* `addlog 1 t/has a pet named poki`
-* `addlog 2 t/recommended movies d/the martian, interstellar, three idiots`
+* `addlog 1 ttl/has a pet named poki`
+* `addlog John ttl/recommended movies d/the martian, interstellar, three idiots`
 
 ### Editing a log: `editlog`
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -131,9 +131,9 @@ Amigos provides functionality to manage logs, which are essentially detailed not
 
 Adds a log to an existing friend at the specified `INDEX` in Amigos.
 The `INDEX` refers to the index number shown in the displayed person's list.
-Format: `addlog INDEX t/[TITLE] d/[DESCRIPTION]`
+Format: `addlog INDEX ? n/NAME t/[TITLE] d/[DESCRIPTION]`
 
-* The `INDEX` field is compulsory.
+* Exactly one of `INDEX` or the `NAME` fields is compulsory.
 * If the `TITLE` argument is provided, then the `DESCRIPTON` argument is optional.
 * If neither `TITLE` nor `DESCRIPTION` arguments are provided, then a GUI
   pop up will prompt the user to key in the title and longer-form text as the description.

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -62,9 +62,13 @@ public class AddLogCommand extends Command {
         this.byName = false;
     }
 
+    /**
+     * Creates an AddLogCommand to add the specified {@code Log} to the specified
+     * {@code Person}.
+     */
     public AddLogCommand(Name name, AddLogDescriptor addLogDescriptor) {
         requireAllNonNull(name, addLogDescriptor);
-        this.personWithNameToAddLog = new Person(new Name(null));
+        this.personWithNameToAddLog = new Person(name);
         this.index = null;
         this.addLogDescriptor = addLogDescriptor;
         this.byName = true;

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -3,6 +3,7 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 
 import java.util.ArrayList;
@@ -33,7 +34,7 @@ public class AddLogCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a log to an existing friend in Amigos. "
             + "Parameters: "
-            + "INDEX "
+            + "INDEX or " + PREFIX_NAME + "NAME"
             + PREFIX_TITLE + "TITLE"
             + " [" + PREFIX_DESCRIPTION + "DESCRIPTION]\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -14,6 +14,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Description;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Log;
 import seedu.address.model.person.Name;
@@ -55,9 +56,6 @@ public class AddLogCommand extends Command {
         this.addLogDescriptor = addLogDescriptor;
     }
 
-//    public AddLogCommand(Name name, AddLogDescriptor addLogDescriptor) {
-//
-//    }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
@@ -93,9 +91,10 @@ public class AddLogCommand extends Command {
         Phone phone = personToEdit.getPhone();
         Email email = personToEdit.getEmail();
         Address address = personToEdit.getAddress();
+        Description description = personToEdit.getDescription();
         Set<Tag> tags = personToEdit.getTags();
         List<Log> updatedLogs = addLogDescriptor.getLogsAfterAdd(personToEdit); // main logic encompassed here
-        return new Person(name, phone, email, address, tags, updatedLogs);
+        return new Person(name, phone, email, address, description, tags, updatedLogs);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -82,7 +82,7 @@ public class AddLogCommand extends Command {
             // find person with same name
             List<Person> personsToEdit = model.getAddressBook()
                     .getPersonList().stream()
-                    .filter(p -> p.isSamePerson(this.personWithNameToAddLog))
+                    .filter(p -> p.hasSameName(this.personWithNameToAddLog))
                     .collect(Collectors.toList());
 
             // if person not found, throw an error

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -55,6 +55,10 @@ public class AddLogCommand extends Command {
         this.addLogDescriptor = addLogDescriptor;
     }
 
+//    public AddLogCommand(Name name, AddLogDescriptor addLogDescriptor) {
+//
+//    }
+
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
@@ -66,6 +70,7 @@ public class AddLogCommand extends Command {
         if (this.index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(MESSAGE_INVALID_INDEX);
         }
+
         Person personToEdit = lastShownList.get(this.index.getZeroBased());
         Person addedLogPerson = createAddedLogPerson(personToEdit, this.addLogDescriptor);
 

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -34,7 +34,7 @@ public class AddLogCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a log to an existing friend in Amigos. "
             + "Parameters: "
-            + "INDEX or " + PREFIX_NAME + "NAME"
+            + "INDEX ? " + PREFIX_NAME + "NAME "
             + PREFIX_TITLE + "TITLE"
             + " [" + PREFIX_DESCRIPTION + "DESCRIPTION]\n"
             + "Example: " + COMMAND_WORD + " "

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -3,20 +3,15 @@ package seedu.address.logic.commands;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
-import java.util.ArrayList;
-import java.util.HashSet;
-
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.Log;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
-import seedu.address.model.tag.Tag;
 
 
 /**
@@ -52,11 +47,10 @@ public class DeleteCommand extends Command {
 
         requireNonNull(model);
 
-        Person personWithNameToDelete = new Person(nameOfPersonToDelete, dummyPhone,
-                dummyEmail, dummyAddress, new HashSet<Tag>(), new ArrayList<Log>());
+        Person personWithNameToDelete = new Person(nameOfPersonToDelete);
 
-        if (!model.hasPerson(personWithNameToDelete)) { //model.hasPerson considers 2 Persons with same name
-            //to be the same Person
+        if (!model.hasPerson(personWithNameToDelete)) { // model.hasPerson considers 2 Persons with same name
+            // to be the same Person
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_NAME);
         }
 

--- a/src/main/java/seedu/address/logic/commands/DeleteLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLogCommand.java
@@ -16,6 +16,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.DeleteLogCommandParser;
 import seedu.address.model.Model;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Description;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.Log;
 import seedu.address.model.person.Name;
@@ -220,9 +221,10 @@ public class DeleteLogCommand extends Command {
             Phone phone = personToEdit.getPhone();
             Email email = personToEdit.getEmail();
             Address address = personToEdit.getAddress();
+            Description description = personToEdit.getDescription();
             Set<Tag> tags = personToEdit.getTags();
             List<Log> emptyLogs = new ArrayList<>(); // main logic encompassed here
-            return new Person(name, phone, email, address, tags, emptyLogs);
+            return new Person(name, phone, email, address, description, tags, emptyLogs);
         }
 
         /**
@@ -266,8 +268,9 @@ public class DeleteLogCommand extends Command {
             Email email = personToEdit.getEmail();
             Address address = personToEdit.getAddress();
             Set<Tag> tags = personToEdit.getTags();
+            Description description = personToEdit.getDescription();
             List<Log> updatedLogs = getLogsAfterDelete(personToEdit, toDelete); // main logic encompassed here
-            return new Person(name, phone, email, address, tags, updatedLogs);
+            return new Person(name, phone, email, address, description, tags, updatedLogs);
         }
 
         /**

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -100,7 +100,9 @@ public class EditCommand extends Command {
         Address updatedAddress = editPersonDescriptor.getAddress().orElse(personToEdit.getAddress());
         Set<Tag> updatedTags = editPersonDescriptor.getTags().orElse(personToEdit.getTags());
         List<Log> updatedLogs = editPersonDescriptor.getLogs().orElse(personToEdit.getLogs());
-        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, updatedTags, updatedLogs);
+        // todo implement editfriend with description
+        return new Person(updatedName, updatedPhone, updatedEmail, updatedAddress, null, updatedTags, updatedLogs);
+
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -56,7 +56,7 @@ public class AddCommandParser implements Parser<AddCommand> {
                 : null;
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
 
-        Person person = new Person(name, phone, email, address, description, tagList);
+        Person person = new Person(name, phone, email, address, description, tagList, null); // explicitly no logs
 
         return new AddCommand(person);
     }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -9,8 +9,6 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Set;
 
 import seedu.address.logic.commands.AddCommand;
@@ -18,7 +16,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Description;
 import seedu.address.model.person.Email;
-import seedu.address.model.person.Log;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
@@ -47,18 +44,17 @@ public class AddCommandParser implements Parser<AddCommand> {
         Name name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         Phone phone = argMultimap.getValue(PREFIX_PHONE).isPresent()
                 ? ParserUtil.parsePhone(argMultimap.getValue(PREFIX_PHONE).get())
-                : new Phone(null);
+                : null;
         Email email = argMultimap.getValue(PREFIX_EMAIL).isPresent()
                 ? ParserUtil.parseEmail(argMultimap.getValue(PREFIX_EMAIL).get())
-                : new Email(null);
+                : null;
         Address address = argMultimap.getValue(PREFIX_ADDRESS).isPresent()
                 ? ParserUtil.parseAddress(argMultimap.getValue(PREFIX_ADDRESS).get())
-                : new Address(null);
+                : null;
         Description description = argMultimap.getValue(PREFIX_DESCRIPTION).isPresent()
                 ? ParserUtil.parsePersonDescription(argMultimap.getValue(PREFIX_DESCRIPTION).get())
-                : new Description(null);
+                : null;
         Set<Tag> tagList = ParserUtil.parseTags(argMultimap.getAllValues(PREFIX_TAG));
-        List<Log> logList = new ArrayList<>();
 
         Person person = new Person(name, phone, email, address, description, tagList);
 

--- a/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
@@ -11,6 +11,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddLogCommand;
 import seedu.address.logic.commands.AddLogCommand.AddLogDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.person.Name;
 
 /**
  * Parses input arguments and creates a new AddLogCommand object
@@ -30,21 +31,27 @@ public class AddLogCommandParser implements Parser<AddLogCommand> {
         ArgumentMultimap argMultimap =
                 ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_TITLE, PREFIX_DESCRIPTION);
 
-        Index index;
+        Name name = null;
+        Index index = null;
 
-        // ensure title prefix and index are present
+        // ensure title prefix is present
         if (!arePrefixesPresent(argMultimap, PREFIX_TITLE)) {
             throw new ParseException(MESSAGE_INVALID_FORMAT);
         }
-        if (argMultimap.getPreamble().isEmpty()) {
+
+        // ensure exactly one of index or name prefix is present
+        boolean hasIndex = !argMultimap.getPreamble().isEmpty();
+        boolean hasName = arePrefixesPresent(argMultimap, PREFIX_NAME);
+        if ((!hasIndex && !hasName)
+            || (hasIndex && hasName)) {
             throw new ParseException(MESSAGE_INVALID_FORMAT);
         }
 
-        // parse
-        try {
+        // parse index or name
+        if (hasIndex) {
             index = ParserUtil.parseIndex(argMultimap.getPreamble());
-        } catch (ParseException pe) {
-            throw new ParseException(MESSAGE_INVALID_FORMAT, pe);
+        } else {
+            name = ParserUtil.parseName(argMultimap.getValue(PREFIX_NAME).get());
         }
 
         // wrap new log into helper class
@@ -64,6 +71,12 @@ public class AddLogCommandParser implements Parser<AddLogCommand> {
             throw new ParseException(MESSAGE_INVALID_FORMAT);
         }
 
-        return new AddLogCommand(index, addLogDescriptor);
+        AddLogCommand command;
+        if (hasIndex) {
+            command = new AddLogCommand(index, addLogDescriptor);
+        } else {
+            command = new AddLogCommand(name, addLogDescriptor);
+        }
+        return command;
     }
 }

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
+import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -65,6 +66,11 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(person);
         return persons.contains(person);
     }
+
+//    public boolean hasPerson(Name name) { // todo should be PersonName object
+//        requireNonNull(name);
+//        Person
+//    }
 
     /**
      * Adds a person to the address book.

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -5,7 +5,6 @@ import static java.util.Objects.requireNonNull;
 import java.util.List;
 
 import javafx.collections.ObservableList;
-import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.UniquePersonList;
 
@@ -66,11 +65,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         requireNonNull(person);
         return persons.contains(person);
     }
-
-//    public boolean hasPerson(Name name) { // todo should be PersonName object
-//        requireNonNull(name);
-//        Person
-//    }
 
     /**
      * Adds a person to the address book.

--- a/src/main/java/seedu/address/model/event/Event.java
+++ b/src/main/java/seedu/address/model/event/Event.java
@@ -3,19 +3,15 @@ package seedu.address.model.event;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.model.AddressBook;
-import seedu.address.model.person.Address;
 import seedu.address.model.person.Description;
-import seedu.address.model.person.Email;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
-import seedu.address.model.person.Phone;
 
 /**
  * Represents an Event in Amigos.
@@ -78,13 +74,12 @@ public class Event {
      */
     public boolean areFriendNamesValid(AddressBook addressBook) {
         // There ought to be a better way of doing this - search AddressBook by name perhaps?
-        final Phone dummyPhone = new Phone("12345678");
-        final Email dummyEmail = new Email("dummyemail@gmail.com");
-        final Address dummyAddress = new Address("Dummy Address");
+        // worth thinking about - how to enforce search specifically by name, rather than relying
+        // on the ::hasPerson(Person) method. todo implement search by name (specifically name objects match)
+
         for (Name name : getFriendNames()) {
-            Person dummyPerson = new Person(name, dummyPhone, dummyEmail, dummyAddress, new HashSet<>(),
-                    new ArrayList<>());
-            if (!addressBook.hasPerson(dummyPerson)) {
+            Person beingLookedFor = new Person(name);
+            if (!addressBook.hasPerson(beingLookedFor)) {
                 return false;
             }
         }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -99,8 +99,8 @@ public class Person {
     }
 
     /**
-     * Returns true if both persons have the same name.
-     * This defines a weaker notion of equality between two persons.
+     * Returns true if both persons are the same, which we define to be
+     * having the same name.
      */
     public boolean isSamePerson(Person otherPerson) {
         if (otherPerson == this) {
@@ -109,6 +109,13 @@ public class Person {
 
         return otherPerson != null
                 && otherPerson.getName().equals(getName());
+    }
+
+    /**
+     * Returns true if both persons explicitly have the same name.
+     */
+    public boolean hasSameName(Person otherPerson) {
+        return this.name.equals(otherPerson.name);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -2,7 +2,6 @@ package seedu.address.model.person;
 
 import static java.util.Objects.isNull;
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -21,65 +20,46 @@ public class Person {
 
     // Identity fields
     private final Name name;
-    private final Phone phone;
-    private final Email email;
+
 
     // Data fields
+    private final Phone phone;
+    private final Email email;
     private final Address address;
     private final Description description;
     private final Set<Tag> tags = new HashSet<>();
     private final UniqueLogList logs = new UniqueLogList();
 
     /**
-     * Constructs a Person
+     * Constructs a person.
      *
-     * @param name Name of person
-     * @param phone Phone of person
-     * @param email Email of person
-     * @param address Address of person
-     * @param description Description of person
-     * @param tags Tag(s) of person
+     * @param name        Name of the person. Compulsory.
+     * @param phone       Phone object of the person. If null, default to no phone.
+     * @param email       Phone object of the person. If null, default to no email.
+     * @param address     Phone object of the person. If null, default to no address.
+     * @param description Phone object of the person. If null, default to no description.
+     * @param tags        Set of tags of the person. If null, default to no tags.
+     * @param logs        Log list of the person. if null, default to no logs.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Description description, Set<Tag> tags) {
+    public Person(Name name, Phone phone, Email email, Address address, Description description, Set<Tag> tags, List<Log> logs) {
         requireNonNull(name);
         this.name = name;
         this.phone = isNull(phone) ? new Phone(null) : phone;
         this.email = isNull(email) ? new Email(null) : email;
         this.address = isNull(address) ? new Address(null) : address;
         this.description = isNull(description) ? new Description(null) : description;
-        this.tags.addAll(tags);
-        this.logs.setLogs(new ArrayList<>());
+        this.tags.addAll(isNull(tags) ? new HashSet<>() : tags);
+        this.logs.setLogs(isNull(logs) ? new ArrayList<>() : logs);
+
     }
 
     /**
-     * Overloaded method to construct a person to have a description with null value.
-     * Every field must be present and not null.
+     * Overloaded method to construct a person with only a name.
+     *
+     * @param name Name of the person. Compulsory.
      */
-    public Person(Name name, Phone phone, Email email, Address address, Set<Tag> tags, List<Log> logs) {
-        requireAllNonNull(name, phone, email, address, tags, logs);
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
-        this.description = new Description(null);
-        this.tags.addAll(tags);
-        this.logs.setLogs(logs);
-    }
-
-    /**
-     * Overloaded method to construct a person to have an empty list of logs.
-     * Every field must be present and not null.
-     */
-    public Person(Name name, Phone phone, Email email, Address address, Description description, Set<Tag> tags,
-                  List<Log> logs) {
-        requireAllNonNull(name, phone, email, address, tags);
-        this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
-        this.description = description;
-        this.tags.addAll(tags);
-        this.logs.setLogs(logs);
+    public Person(Name name) {
+        this(name, null, null, null, null, null, null);
     }
 
     public Name getName() {

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,5 +1,7 @@
 package seedu.address.model.person;
 
+import static java.util.Objects.isNull;
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
@@ -39,15 +41,14 @@ public class Person {
      * @param tags Tag(s) of person
      */
     public Person(Name name, Phone phone, Email email, Address address, Description description, Set<Tag> tags) {
-        requireAllNonNull(name, phone, email, address, tags);
+        requireNonNull(name);
         this.name = name;
-        this.phone = phone;
-        this.email = email;
-        this.address = address;
-        this.description = description;
+        this.phone = isNull(phone) ? new Phone(null) : phone;
+        this.email = isNull(email) ? new Email(null) : email;
+        this.address = isNull(address) ? new Address(null) : address;
+        this.description = isNull(description) ? new Description(null) : description;
         this.tags.addAll(tags);
         this.logs.setLogs(new ArrayList<>());
-
     }
 
     /**

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -27,22 +27,22 @@ public class SampleDataUtil {
         return new Person[] {
             new Person(new Name("Alex Yeoh"), new Phone("87438807"), new Email("alexyeoh@example.com"),
                 new Address("Blk 30 Geylang Street 29, #06-40"), new Description("Friends since high school"),
-                getTagSet("friends")),
+                getTagSet("friends"), null),
             new Person(new Name("Bernice Yu"), new Phone("99272758"), new Email("berniceyu@example.com"),
                 new Address("Blk 30 Lorong 3 Serangoon Gardens, #07-18"), new Description("Friday lunch buddy"),
-                getTagSet("colleagues", "friends")),
+                getTagSet("colleagues", "friends"), null),
             new Person(new Name("Charlotte Oliveiro"), new Phone("93210283"), new Email("charlotte@example.com"),
                 new Address("Blk 11 Ang Mo Kio Street 74, #11-04"), new Description("Deskmate in CS1010S"),
-                getTagSet("neighbours")),
+                getTagSet("neighbours"), null),
             new Person(new Name("David Li"), new Phone("91031282"), new Email("lidavid@example.com"),
                 new Address("Blk 436 Serangoon Gardens Street 26, #16-43"), new Description("Loves to steal my food"),
-                getTagSet("family")),
+                getTagSet("family"), null),
             new Person(new Name("Irfan Ibrahim"), new Phone("92492021"), new Email("irfan@example.com"),
                 new Address("Blk 47 Tampines Street 20, #17-35"), new Description("Friends since junior college"),
-                getTagSet("classmates")),
+                getTagSet("classmates"), null),
             new Person(new Name("Roy Balakrishnan"), new Phone("92624417"), new Email("royb@example.com"),
                 new Address("Blk 45 Aljunied Street 85, #11-31"), new Description("Takes the same bus as me"),
-                getTagSet("colleagues"))
+                getTagSet("colleagues"), null)
         };
     }
 

--- a/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddLogCommandParserTest.java
@@ -3,19 +3,25 @@ package seedu.address.logic.parser;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOG_TITLE_EMPTY_STRING_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOG_TITLE_ONLY_SPACES_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.INVALID_LOG_TITLE_TOO_LONG_DESC;
+import static seedu.address.logic.commands.CommandTestUtil.INVALID_NAME_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LOG_DESCRIPTION_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LOG_DESCRIPTION_DIFFERENT_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LOG_TITLE_DESC;
 import static seedu.address.logic.commands.CommandTestUtil.LOG_TITLE_DESC_PRECEDING_SPACE;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.NAME_DESC_BOB;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_DESCRIPTION;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_DESCRIPTION_OTHER;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_TITLE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_AMY;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_BOB;
 import static seedu.address.logic.parser.AddLogCommandParser.MESSAGE_INVALID_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.logic.parser.ParserUtil.MESSAGE_INVALID_INDEX;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
 import org.junit.jupiter.api.Test;
@@ -24,6 +30,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.AddLogCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.model.person.Log;
+import seedu.address.model.person.Name;
 
 public class AddLogCommandParserTest {
 
@@ -35,10 +42,14 @@ public class AddLogCommandParserTest {
 
         String args;
 
-        // no index specified
+        // no index or name specified
         args = LOG_TITLE_DESC;
         assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
         args = LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+
+        // both index and name specified
+        args = INDEX_FIRST_PERSON.getOneBased() + NAME_DESC_AMY + LOG_TITLE_DESC;
         assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
 
         // no title specified
@@ -62,15 +73,15 @@ public class AddLogCommandParserTest {
 
         // negative index
         args = "-5" + LOG_TITLE_DESC;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_INDEX);
 
         // zero index, since list should be 1-indexed
         args = "0" + LOG_TITLE_DESC;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_INDEX);
 
         // invalid arguments being parsed as preamble
         args = "somegarbagepreamble" + LOG_TITLE_DESC;
-        assertParseFailure(parser, args, MESSAGE_INVALID_FORMAT);
+        assertParseFailure(parser, args, MESSAGE_INVALID_INDEX);
 
     }
 
@@ -90,6 +101,7 @@ public class AddLogCommandParserTest {
 
         String args;
 
+        // ===== WITH INDEX =====
         // invalid titles
         args = "1" + INVALID_LOG_TITLE_EMPTY_STRING_DESC;
         assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
@@ -103,7 +115,24 @@ public class AddLogCommandParserTest {
         assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
         args = "1" + " " + PREFIX_TITLE + " " + PREFIX_DESCRIPTION;
         assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
+        args = "1" + " " + PREFIX_TITLE + " " + PREFIX_DESCRIPTION;
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
 
+        // ===== WITH NAME =====
+        args = NAME_DESC_AMY + INVALID_LOG_TITLE_EMPTY_STRING_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
+        args = NAME_DESC_AMY + INVALID_LOG_TITLE_ONLY_SPACES_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
+        args = NAME_DESC_AMY + INVALID_LOG_TITLE_TOO_LONG_DESC;
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
+
+        // prefixes without actual arguments
+        args = NAME_DESC_AMY + " " + PREFIX_TITLE;
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
+        args = NAME_DESC_AMY + " " + PREFIX_TITLE + " " + PREFIX_DESCRIPTION;
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
+        args = NAME_DESC_AMY + " " + PREFIX_TITLE + " " + PREFIX_DESCRIPTION;
+        assertParseFailure(parser, args, MESSAGE_INVALID_TITLE);
     }
 
     @Test
@@ -113,6 +142,7 @@ public class AddLogCommandParserTest {
         AddLogCommand.AddLogDescriptor descriptor;
         Index targetIndex = INDEX_FIRST_PERSON;
 
+        // ===== WITH INDEX =====
         // valid title
         args = targetIndex.getOneBased() + LOG_TITLE_DESC;
         descriptor = new AddLogCommand.AddLogDescriptor();
@@ -134,22 +164,64 @@ public class AddLogCommandParserTest {
         descriptor.setNewDescription(VALID_LOG_DESCRIPTION);
         expectedCommand = new AddLogCommand(targetIndex, descriptor);
         assertParseSuccess(parser, args, expectedCommand);
+
+        // ===== WITH NAME =====
+        Name targetName = new Name(VALID_NAME_AMY);
+
+        // valid title
+        args = NAME_DESC_AMY + LOG_TITLE_DESC;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE);
+        expectedCommand = new AddLogCommand(targetName, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+
+        // another valid title
+        args = NAME_DESC_AMY + LOG_TITLE_DESC_PRECEDING_SPACE;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED);
+        expectedCommand = new AddLogCommand(targetName, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+
+        // valid title and description
+        args = NAME_DESC_AMY + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE);
+        descriptor.setNewDescription(VALID_LOG_DESCRIPTION);
+        expectedCommand = new AddLogCommand(targetName, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+
     }
 
     @Test
     public void parse_multipleRepeatedFields_acceptsLast() {
+
+        // ===== WITH INDEX =====
         Index targetIndex = INDEX_FIRST_PERSON;
         String args = targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_TITLE_DESC_PRECEDING_SPACE
                 + LOG_DESCRIPTION_DESC + LOG_DESCRIPTION_DIFFERENT_DESC;
+
         AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
         descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED);
         descriptor.setNewDescription(VALID_LOG_DESCRIPTION_OTHER);
         AddLogCommand expectedCommand = new AddLogCommand(targetIndex, descriptor);
+
+        assertParseSuccess(parser, args, expectedCommand);
+
+        // ===== WITH NAME =====
+        // expected to take last name
+        Name targetName = new Name(VALID_NAME_BOB);
+        args = NAME_DESC_AMY + NAME_DESC_BOB + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE);
+        descriptor.setNewDescription(VALID_LOG_DESCRIPTION);
+        expectedCommand = new AddLogCommand(targetName, descriptor);
         assertParseSuccess(parser, args, expectedCommand);
     }
 
     @Test
     public void parse_multipleInvalidFieldsButLastValid_success() {
+
+        // ===== WITH INDEX =====
         Index targetIndex = INDEX_FIRST_PERSON;
         String args = targetIndex.getOneBased() + INVALID_LOG_TITLE_EMPTY_STRING_DESC + LOG_TITLE_DESC_PRECEDING_SPACE
                 + LOG_DESCRIPTION_DESC + LOG_DESCRIPTION_DIFFERENT_DESC;
@@ -157,6 +229,16 @@ public class AddLogCommandParserTest {
         descriptor.setNewTitle(VALID_LOG_TITLE_PRECEDING_SPACE_TRIMMED);
         descriptor.setNewDescription(VALID_LOG_DESCRIPTION_OTHER);
         AddLogCommand expectedCommand = new AddLogCommand(targetIndex, descriptor);
+        assertParseSuccess(parser, args, expectedCommand);
+
+        // ===== WITH NAME =====
+        // expected to take last name
+        Name targetName = new Name(VALID_NAME_BOB);
+        args = INVALID_NAME_DESC + NAME_DESC_BOB + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+        descriptor = new AddLogCommand.AddLogDescriptor();
+        descriptor.setNewTitle(VALID_LOG_TITLE);
+        descriptor.setNewDescription(VALID_LOG_DESCRIPTION);
+        expectedCommand = new AddLogCommand(targetName, descriptor);
         assertParseSuccess(parser, args, expectedCommand);
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -94,6 +94,27 @@ public class PersonTest {
         assertFalse(ALICE.equals(editedAlice));
         Person editedAliceWithDifferentDescriptions = new PersonBuilder(ALICE)
                 .withLogs(TypicalLogs.getIdenticalButDifferentTypicalLogs()).build();
+        assertFalse(ALICE.equals(editedAliceWithDifferentDescriptions));
+
+    }
+
+    @Test
+    public void hasSameName() {
+
+        // no other fields
+        Name name = new Name("some valid name");
+        Name repeatedName = new Name("some valid name");
+
+        Person person = new Person(name);
+        Person otherPerson = new Person(repeatedName);
+        assertTrue(person.hasSameName(otherPerson));
+
+        // returns true even with different attributes
+        Person editedAlice = new PersonBuilder(ALICE).withLogs(TypicalLogs.getTypicalLogs()).build();
+        assertTrue(ALICE.hasSameName(editedAlice));
+
+        // returns false
+        assertFalse(ALICE.hasSameName(BOB));
 
     }
 }


### PR DESCRIPTION
Fixes #87 

Added name-based `addlog`.

Notable changes, aside from the obvious:

# 1. Refactored `Person` class constructor to handle `null` values, and overloaded it to handle a specific case with only a `Name` object

The rationale is since a person's name is a primary key, we can use these dummy `Person` objects to find them in the `Model`. Do note, however, that this is probably bad practice. Which brings me to the second point. 

# 2. Added `Person::hasSameName` method for explicit finding of people with the same name

This method allows for well-defined behaviour. As much as we know that a `Person` is uniquely defined by their name, creating dummy `Person` objects with the name we are trying to find is bad practice since we implicitly rely on the `isSamePerson` method, which could be subject to change. So I've created this method as a way around it. 