### PR TITLE
Branch v1.3 refactor index name commands

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -16,6 +16,7 @@ import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.common.Description;
+import seedu.address.model.common.Name;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
 import seedu.address.model.person.FriendName;
@@ -29,7 +30,7 @@ import seedu.address.model.tag.Tag;
 /**
  * Adds a log to a person in the address book.
  */
-public class AddLogCommand extends Command {
+public class AddLogCommand extends ByIndexByNameCommand {
 
     public static final String COMMAND_WORD = "addlog";
 
@@ -44,11 +45,9 @@ public class AddLogCommand extends Command {
 
     public static final String MESSAGE_ADD_LOG_SUCCESS = "New log added!";
     public static final String MESSAGE_DUPLICATE_LOG = "This log already exists for this friend.";
-    public static final String MESSAGE_INVALID_INDEX = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
-    public static final String MESSAGE_PERSON_NOT_FOUND = Messages.MESSAGE_INVALID_PERSON_NAME;
 
     private final Index index;
-    private final Person personWithNameToAddLog;
+    private final Name nameToAddLog;
     private final AddLogDescriptor addLogDescriptor;
     private final boolean byName;
 
@@ -59,7 +58,7 @@ public class AddLogCommand extends Command {
     public AddLogCommand(Index index, AddLogDescriptor addLogDescriptor) {
         requireAllNonNull(index, addLogDescriptor);
         this.index = index;
-        this.personWithNameToAddLog = null;
+        this.nameToAddLog = null;
         this.addLogDescriptor = addLogDescriptor;
         this.byName = false;
     }
@@ -70,7 +69,7 @@ public class AddLogCommand extends Command {
      */
     public AddLogCommand(FriendName name, AddLogDescriptor addLogDescriptor) {
         requireAllNonNull(name, addLogDescriptor);
-        this.personWithNameToAddLog = new Person(name);
+        this.nameToAddLog = name;
         this.index = null;
         this.addLogDescriptor = addLogDescriptor;
         this.byName = true;
@@ -84,30 +83,9 @@ public class AddLogCommand extends Command {
         Person personToEdit;
 
         if (this.byName) {
-
-            // find person with same name
-            List<Person> personsToEdit = model.getAddressBook()
-                    .getPersonList().stream()
-                    .filter(p -> p.hasSameName(this.personWithNameToAddLog))
-                    .collect(Collectors.toList());
-
-            // if person not found, throw an error
-            if (personsToEdit.size() < 1) {
-                throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
-            }
-            assert (personsToEdit.size() == 1);
-            personToEdit = personsToEdit.get(0);
-
+            personToEdit = this.getPersonByName(model, this.nameToAddLog);
         } else {
-
-            // get list of persons from model
-            List<Person> lastShownList = model.getFilteredPersonList();
-
-            // get person and modify
-            if (this.index.getZeroBased() >= lastShownList.size()) {
-                throw new CommandException(MESSAGE_INVALID_INDEX);
-            }
-            personToEdit = lastShownList.get(this.index.getZeroBased());
+            personToEdit = this.getPersonByFilteredIndex(model, this.index);
         }
 
         // create person with added logs
@@ -161,10 +139,10 @@ public class AddLogCommand extends Command {
         // compare name or index
         if ((this.byName) && (a.byName)) {
             assert ((this.index == null) && (a.index == null));
-            return this.personWithNameToAddLog.equals(a.personWithNameToAddLog);
+            return this.nameToAddLog.equals(a.nameToAddLog);
 
         } else if ((!this.byName) && (!a.byName)) {
-            assert ((this.personWithNameToAddLog == null) && (a.personWithNameToAddLog == null));
+            assert ((this.nameToAddLog == null) && (a.nameToAddLog == null));
             return this.index.equals(a.index);
         }
 

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -9,9 +9,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TITLE;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 
-import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;

--- a/src/main/java/seedu/address/logic/commands/ByIndexByNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ByIndexByNameCommand.java
@@ -1,16 +1,16 @@
 package seedu.address.logic.commands;
 
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.common.Name;
 import seedu.address.model.person.Person;
-
-import java.util.List;
-import java.util.stream.Collectors;
-
-import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 /**
  * Represents a command with hidden internal logic and the ability to be executed,
@@ -28,7 +28,7 @@ public abstract class ByIndexByNameCommand extends Command {
      *
      * @throws CommandException if name provided does not exist in the model.
      */
-    public Person getPersonByName(Model model, Name name) throws CommandException {
+    public static Person getPersonByName(Model model, Name name) throws CommandException {
         requireAllNonNull(model, name);
         // find person with same name
         List<Person> personsToEdit = model.getAddressBook()
@@ -52,7 +52,7 @@ public abstract class ByIndexByNameCommand extends Command {
      *
      * @throws CommandException if index provided is out of bounds.
      */
-    public Person getPersonByFilteredIndex(Model model, Index index) throws CommandException {
+    public static Person getPersonByFilteredIndex(Model model, Index index) throws CommandException {
         requireAllNonNull(model, index);
 
         // get list of persons from model

--- a/src/main/java/seedu/address/logic/commands/ByIndexByNameCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ByIndexByNameCommand.java
@@ -1,0 +1,68 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.common.Name;
+import seedu.address.model.person.Person;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
+
+/**
+ * Represents a command with hidden internal logic and the ability to be executed,
+ * specifically with the requirement that it supports INDEX and NAME based access to persons
+ * in Amigos.
+ */
+public abstract class ByIndexByNameCommand extends Command {
+
+    public static final String MESSAGE_INVALID_INDEX = Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
+    public static final String MESSAGE_PERSON_NOT_FOUND = Messages.MESSAGE_INVALID_PERSON_NAME;
+
+    /**
+     * Gets a person by name from the model. Assumes that for a given name, there is
+     * exactly one person with the name.
+     *
+     * @throws CommandException if name provided does not exist in the model.
+     */
+    public Person getPersonByName(Model model, Name name) throws CommandException {
+        requireAllNonNull(model, name);
+        // find person with same name
+        List<Person> personsToEdit = model.getAddressBook()
+                .getPersonList().stream()
+                .filter(p -> p.hasName(name))
+                .collect(Collectors.toList());
+
+        // if person not found, throw an error
+        if (personsToEdit.size() < 1) {
+            throw new CommandException(MESSAGE_PERSON_NOT_FOUND);
+        }
+
+        // assumes exactly one person with a given name, assertion to check
+        assert (personsToEdit.size() == 1);
+
+        return personsToEdit.get(0);
+    }
+
+    /**
+     * Gets a person from the model by his index in the filtered list.
+     *
+     * @throws CommandException if index provided is out of bounds.
+     */
+    public Person getPersonByFilteredIndex(Model model, Index index) throws CommandException {
+        requireAllNonNull(model, index);
+
+        // get list of persons from model
+        List<Person> lastShownList = model.getFilteredPersonList();
+
+        // ensure that index is valid
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(MESSAGE_INVALID_INDEX);
+        }
+
+        return lastShownList.get(index.getZeroBased());
+    }
+}

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -1,6 +1,7 @@
 package seedu.address.model.person;
 
 import static java.util.Objects.isNull;
+import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.ArrayList;
@@ -11,6 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 
 import seedu.address.model.common.Description;
+import seedu.address.model.common.Name;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -167,6 +169,14 @@ public class Person {
      */
     public boolean hasSameName(Person otherPerson) {
         return this.name.equals(otherPerson.name);
+    }
+
+    /**
+     * Returns true if the person has a name equal to the specified name.
+     */
+    public boolean hasName(Name name) {
+        requireNonNull(name);
+        return this.name.equals(name);
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/DeleteLogCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteLogCommandTest.java
@@ -31,6 +31,7 @@ public class DeleteLogCommandTest {
     private static final String MESSAGE_SUCCESS = DeleteLogCommand.MESSAGE_DELETE_LOG_SUCCESS;
     private static final String MESSAGE_PERSON_NOT_FOUND = DeleteLogCommand.MESSAGE_PERSON_NOT_FOUND;
     private static final String MESSAGE_LOG_NOT_FOUND = DeleteLogCommand.MESSAGE_LOG_NOT_FOUND;
+    private static final String MESSAGE_INVALID_INDEX = DeleteLogCommand.MESSAGE_INVALID_INDEX;
 
     // ===== UNIT TESTS =====
     @Test
@@ -257,7 +258,7 @@ public class DeleteLogCommandTest {
                 Index.fromOneBased(2000), // not in address book
                 null); // no log specified
 
-        assertCommandFailure(command, model, MESSAGE_PERSON_NOT_FOUND);
+        assertCommandFailure(command, model, MESSAGE_INVALID_INDEX);
 
         // ===== EMPTY ADDRESS BOOK =====
         model = new ModelManager();
@@ -266,7 +267,7 @@ public class DeleteLogCommandTest {
                 INDEX_FIRST_PERSON, // first person, but empty address book
                 null); // no log specified
 
-        assertCommandFailure(command, model, MESSAGE_PERSON_NOT_FOUND);
+        assertCommandFailure(command, model, MESSAGE_INVALID_INDEX);
 
     }
 

--- a/src/test/java/seedu/address/model/person/PersonTest.java
+++ b/src/test/java/seedu/address/model/person/PersonTest.java
@@ -117,4 +117,18 @@ public class PersonTest {
         assertFalse(ALICE.hasSameName(BOB));
 
     }
+
+    @Test
+    public void hasName() {
+
+        // return true
+        FriendName name = new FriendName("some valid name");
+        FriendName repeatedName = new FriendName("some valid name");
+
+        Person person = new Person(name);
+        assertTrue(person.hasName(repeatedName));
+
+        // returns false
+        assertFalse(ALICE.hasName(BOB.getName()));
+    }
 }


### PR DESCRIPTION
Fixes #124 

# Motivation

Initially, because we support `addfriend`, `addlog`, `deletelog` and `deletefriend` by `Name` and by `Index` (and also intend to do so for `editfriend` and `editlog`, there was a lot of code duplication in the command execution, where the logic to find a person by name or index was repeated across all of these commands. 

# Changes

So, in this PR:
1. An abstract `ByIndexByNameCommand` with static methods to retrieve the persons from the model is implemented. 
2. Test cases are accordingly updated.

# Design rationale
The idea behind abstracting the methods under `Logic` rather than `Model` was ultimately because the operations were carried out during the execution of a command. 

Consider the alternative where the logic was handled by `Model` - then should exceptions be thrown, either a `CommandException` would be thrown by model (which wouldn't make sense) or a specific exception class would have to be created for the `Model` component, and these would then be thrown and handled by `Command` at execution. The latter design would be unnecessarily complicated. 

This design also has the added benefit of sharing error messages.

# Notes
Note that refactoring was only done for `addlog` and `deletelog`. The analogous refactoring for `addfriend` and `deletefriend` will be done at a later date.
