### PR TITLE
V1.3b command aliases

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -18,8 +18,10 @@ import seedu.address.model.person.Person;
 public class AddCommand extends Command {
 
     public static final String COMMAND_WORD = "addfriend";
+    public static final String COMMAND_ALIAS = "af";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a friend to the address book. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
+            + ": Adds a friend to the address book. "
             + "Parameters: "
             + PREFIX_NAME + "NAME "
             + "[" + PREFIX_PHONE + "PHONE] "

--- a/src/main/java/seedu/address/logic/commands/AddEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEventCommand.java
@@ -17,8 +17,9 @@ import seedu.address.model.event.Event;
 public class AddEventCommand extends Command {
 
     public static final String COMMAND_WORD = "addevent";
+    public static final String COMMAND_ALIAS = "ae";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds an event to Amigos. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS + ": Adds an event to Amigos. "
             + "Parameters: "
             + PREFIX_NAME + "EVENT_NAME "
             + PREFIX_DATETIME + "DATE_TIME "

--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -31,8 +31,10 @@ import seedu.address.model.tag.Tag;
 public class AddLogCommand extends ByIndexByNameCommand {
 
     public static final String COMMAND_WORD = "addlog";
+    public static final String COMMAND_ALIAS = "al";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Adds a log to an existing friend in Amigos. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
+            + ": Adds a log to an existing friend in Amigos. "
             + "Parameters: "
             + "INDEX ? " + PREFIX_NAME + "NAME "
             + PREFIX_TITLE + "TITLE"

--- a/src/main/java/seedu/address/logic/commands/DeleteCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteCommand.java
@@ -23,8 +23,9 @@ import seedu.address.model.person.Phone;
 public class DeleteCommand extends Command {
 
     public static final String COMMAND_WORD = "deletefriend";
+    public static final String COMMAND_ALIAS = "df";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
             + ": Deletes the friend identified by index or name.\n"
             + "Parameters: "
             + PREFIX_NAME + "NAME (name of a friend who exists in Amigos) OR "

--- a/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteEventCommand.java
@@ -16,8 +16,9 @@ import seedu.address.model.event.Event;
 public class DeleteEventCommand extends Command {
 
     public static final String COMMAND_WORD = "deleteevent";
+    public static final String COMMAND_ALIAS = "de";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
             + ": Deletes the event identified by the index number used in the displayed event list.\n"
             + "Parameters: INDEX (must be a positive integer)\n"
             + "Example: " + COMMAND_WORD + " 1";

--- a/src/main/java/seedu/address/logic/commands/DeleteLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteLogCommand.java
@@ -32,8 +32,10 @@ import seedu.address.model.tag.Tag;
 public class DeleteLogCommand extends ByIndexByNameCommand {
 
     public static final String COMMAND_WORD = "deletelog";
+    public static final String COMMAND_ALIAS = "dl";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Deletes a log from an existing friend in Amigos. "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
+            + ": Deletes a log from an existing friend in Amigos. "
             + "Parameters: "
             + "[INDEX ? " + PREFIX_NAME + "NAME] ["
             + PREFIX_LOG_INDEX + "LOG_INDEX]"

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -35,8 +35,9 @@ import seedu.address.model.tag.Tag;
 public class EditCommand extends Command {
 
     public static final String COMMAND_WORD = "editfriend";
+    public static final String COMMAND_ALIAS = "ef";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "

--- a/src/main/java/seedu/address/logic/commands/EditEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEventCommand.java
@@ -31,8 +31,10 @@ import seedu.address.model.person.FriendName;
 public class EditEventCommand extends Command {
 
     public static final String COMMAND_WORD = "editevent";
+    public static final String COMMAND_ALIAS = "ee";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits the details of the person identified "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
+            + ": Edits the details of the person identified "
             + "by the index number used in the displayed person list. "
             + "Existing values will be overwritten by the input values.\n"
             + "Parameters: INDEX (must be a positive integer) "

--- a/src/main/java/seedu/address/logic/commands/EditLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLogCommand.java
@@ -31,8 +31,10 @@ import seedu.address.model.tag.Tag;
 public class EditLogCommand extends ByIndexByNameCommand {
 
     public static final String COMMAND_WORD = "editlog";
+    public static final String COMMAND_ALIAS = "el";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Edits an existing log "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
+            + ": Edits an existing log "
             + "of an existing friend in Amigos. "
             + "Parameters: "
             + "INDEX ? " + PREFIX_NAME + "NAME "

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -13,8 +13,10 @@ import seedu.address.model.person.NameContainsKeywordsPredicate;
 public class FindCommand extends Command {
 
     public static final String COMMAND_WORD = "findfriend";
+    public static final String COMMAND_ALIAS = "ff";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all friends whose names contain any of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
+            + ": Finds all friends whose names contain any of "
             + "the specified keywords (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";

--- a/src/main/java/seedu/address/logic/commands/FindEventCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindEventCommand.java
@@ -16,8 +16,10 @@ import seedu.address.model.event.EventFilterPredicate;
 public class FindEventCommand extends Command {
 
     public static final String COMMAND_WORD = "findevent";
+    public static final String COMMAND_ALIAS = "fe";
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Finds all events whose fields contain all of "
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " / " + COMMAND_ALIAS
+            + ": Finds all events whose fields contain all of "
             + "the specified search terms (case-insensitive) and displays them as a list with index numbers.\n"
             + "Parameters: "
             + "[" + PREFIX_NAME + "EVENT_NAME_SUBSTRING] "

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -10,7 +10,8 @@ import seedu.address.model.Model;
  */
 public class ListCommand extends Command {
 
-    public static final String COMMAND_WORD = "showfriends";
+    public static final String COMMAND_WORD = "listfriends";
+    public static final String COMMAND_ALIAS = "lf";
 
     public static final String MESSAGE_SUCCESS = "Listed all friends";
 

--- a/src/main/java/seedu/address/logic/commands/ShowEventsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowEventsCommand.java
@@ -10,7 +10,8 @@ import seedu.address.model.Model;
  */
 public class ShowEventsCommand extends Command {
 
-    public static final String COMMAND_WORD = "showevents";
+    public static final String COMMAND_WORD = "listevents";
+    public static final String COMMAND_ALIAS = "le";
 
     public static final String MESSAGE_SUCCESS = "Listed all events";
 

--- a/src/main/java/seedu/address/logic/commands/ShowFriendCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowFriendCommand.java
@@ -13,6 +13,7 @@ import seedu.address.model.person.Person;
 public class ShowFriendCommand extends Command {
 
     public static final String COMMAND_WORD = "showfriend";
+    public static final String COMMAND_ALIAS = "sf";
 
     public static final String MESSAGE_USAGE = "COMMAND_WORD : Shows full details of a friend in"
             + " the address book. "

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -54,24 +54,30 @@ public class AddressBookParser {
         switch (commandWord) {
 
         case AddCommand.COMMAND_WORD:
+        case AddCommand.COMMAND_ALIAS:
             return new AddCommandParser().parse(arguments);
 
         case EditCommand.COMMAND_WORD:
+        case EditCommand.COMMAND_ALIAS:
             return new EditCommandParser().parse(arguments);
 
         case DeleteCommand.COMMAND_WORD:
+        case DeleteCommand.COMMAND_ALIAS:
             return new DeleteCommandParser().parse(arguments);
 
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
         case FindCommand.COMMAND_WORD:
+        case FindCommand.COMMAND_ALIAS:
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
+        case ListCommand.COMMAND_ALIAS:
             return new ListCommand();
 
         case ShowFriendCommand.COMMAND_WORD:
+        case ShowFriendCommand.COMMAND_ALIAS:
             return new ShowFriendCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
@@ -81,27 +87,35 @@ public class AddressBookParser {
             return new HelpCommand();
 
         case AddLogCommand.COMMAND_WORD:
+        case AddLogCommand.COMMAND_ALIAS:
             return new AddLogCommandParser().parse(arguments);
 
         case DeleteLogCommand.COMMAND_WORD:
+        case DeleteLogCommand.COMMAND_ALIAS:
             return new DeleteLogCommandParser().parse(arguments);
 
         case EditLogCommand.COMMAND_WORD:
+        case EditLogCommand.COMMAND_ALIAS:
             return new EditLogCommandParser().parse(arguments);
 
         case AddEventCommand.COMMAND_WORD:
+        case AddEventCommand.COMMAND_ALIAS:
             return new AddEventCommandParser().parse(arguments);
 
         case EditEventCommand.COMMAND_WORD:
+        case EditEventCommand.COMMAND_ALIAS:
             return new EditEventCommandParser().parse(arguments);
 
         case DeleteEventCommand.COMMAND_WORD:
+        case DeleteEventCommand.COMMAND_ALIAS:
             return new DeleteEventCommandParser().parse(arguments);
 
         case ShowEventsCommand.COMMAND_WORD:
+        case ShowEventsCommand.COMMAND_ALIAS:
             return new ShowEventsCommand();
 
         case FindEventCommand.COMMAND_WORD:
+        case FindEventCommand.COMMAND_ALIAS:
             return new FindEventCommandParser().parse(arguments);
 
         default:

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -83,7 +83,7 @@ public class AddressBookParserTest {
     public void parseCommandByIndex_deletefriend() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_WORD + " "
             + INDEX_FIRST_PERSON.getOneBased());
-        DeleteCommand commandByAlias = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_ALIAS+ " "
+        DeleteCommand commandByAlias = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_ALIAS + " "
                 + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
 

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -62,20 +62,33 @@ public class AddressBookParserTest {
     public void parseCommand_add() throws Exception {
         Person person = new PersonBuilder().build();
         AddCommand command = (AddCommand) parser.parseCommand(PersonUtil.getAddCommand(person));
+        AddCommand commandByAlias = (AddCommand) parser.parseCommand(PersonUtil.getAddCommandAlias(person));
         assertEquals(new AddCommand(person), command);
+
+        //to check if command alias works
+        assertEquals(new AddCommand(person), commandByAlias);
     }
 
     @Test
     public void parseCommandByName_deletefriend() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_WORD + " n/Dummy Name");
+        DeleteCommand commandByAlias = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_ALIAS + " n/Dummy Name");
         assertEquals(new DeleteCommand(new FriendName("Dummy Name")), command);
+
+        //to check if command alias works
+        assertEquals(new DeleteCommand(new FriendName("Dummy Name")), commandByAlias);
     }
 
     @Test
     public void parseCommandByIndex_deletefriend() throws Exception {
         DeleteCommand command = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_WORD + " "
             + INDEX_FIRST_PERSON.getOneBased());
+        DeleteCommand commandByAlias = (DeleteCommand) parser.parseCommand(DeleteCommand.COMMAND_ALIAS+ " "
+                + INDEX_FIRST_PERSON.getOneBased());
         assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), command);
+
+        //to check if command alias works
+        assertEquals(new DeleteCommand(INDEX_FIRST_PERSON), commandByAlias);
     }
 
     @Test
@@ -90,7 +103,14 @@ public class AddressBookParserTest {
         EditCommand.EditPersonDescriptor descriptor = new EditPersonDescriptorBuilder(person).build();
         EditCommand command = (EditCommand) parser.parseCommand(EditCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+
+        EditCommand commandByAlias = (EditCommand) parser.parseCommand(EditCommand.COMMAND_ALIAS + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + PersonUtil.getEditPersonDescriptorDetails(descriptor));
+
         assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), command);
+
+        //to check if command alias works
+        assertEquals(new EditCommand(INDEX_FIRST_PERSON, descriptor), commandByAlias);
     }
 
     @Test
@@ -100,7 +120,16 @@ public class AddressBookParserTest {
         EditEventCommand command = (EditEventCommand) parser.parseCommand(EditEventCommand.COMMAND_WORD + " "
                 + INDEX_FIRST_PERSON.getOneBased() + " " + "n/Default Event " + "dt/12-5-2022 1500 " + "d/Default Description "
                 + "af/Amy Koh af/Alex Yeoh");
+
+        EditEventCommand commandByAlias = (EditEventCommand) parser.parseCommand(EditEventCommand.COMMAND_ALIAS + " "
+                + INDEX_FIRST_PERSON.getOneBased() + " " + "n/Default Event " + "dt/12-5-2022 1500 " + "d/Default Description "
+                + "af/Amy Koh af/Alex Yeoh");
+
         assertEquals(new EditEventCommand(INDEX_FIRST_PERSON, descriptor), command);
+
+        //to check if command alias works
+        assertEquals(new EditEventCommand(INDEX_FIRST_PERSON, descriptor), commandByAlias);
+
     }
 
     @Test
@@ -114,7 +143,14 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+
+        FindCommand commandByAlias = (FindCommand) parser.parseCommand(
+                FindCommand.COMMAND_ALIAS + " " + keywords.stream().collect(Collectors.joining(" ")));
+
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+
+        //to check if command alias works
+        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), commandByAlias);
     }
 
     @Test
@@ -124,9 +160,11 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_list() throws Exception {
+    public void parseCommand_listfriends() throws Exception {
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD) instanceof ListCommand);
         assertTrue(parser.parseCommand(ListCommand.COMMAND_WORD + " 3") instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS) instanceof ListCommand);
+        assertTrue(parser.parseCommand(ListCommand.COMMAND_ALIAS + " 3") instanceof ListCommand);
     }
 
     @Test
@@ -134,8 +172,16 @@ public class AddressBookParserTest {
         Person person = new PersonBuilder().build();
         ShowFriendCommand command = (ShowFriendCommand) parser.parseCommand(ShowFriendCommand.COMMAND_WORD
                 + " n/" + person.getName().fullName);
+
+        ShowFriendCommand commandByAlias = (ShowFriendCommand) parser.parseCommand(ShowFriendCommand.COMMAND_ALIAS
+                + " n/" + person.getName().fullName);
+
         assertEquals(new ShowFriendCommand(person), command);
+
+        //to check if command alias works
+        assertEquals(new ShowFriendCommand(person), commandByAlias);
     }
+
 
     @Test
     public void parseCommand_addLog() throws Exception {
@@ -145,6 +191,10 @@ public class AddressBookParserTest {
         String validAddLogCommand = AddLogCommand.COMMAND_WORD + " "
                 + targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
 
+        //command by alias
+        String validAddLogCommandByAlias = AddLogCommand.COMMAND_ALIAS + " "
+                + targetIndex.getOneBased() + LOG_TITLE_DESC + LOG_DESCRIPTION_DESC;
+
         // expected command
         AddLogCommand.AddLogDescriptor descriptor = new AddLogCommand.AddLogDescriptor();
         descriptor.setNewTitle(VALID_LOG_TITLE);
@@ -152,7 +202,9 @@ public class AddressBookParserTest {
         AddLogCommand command = new AddLogCommand(INDEX_FIRST_PERSON, descriptor);
 
         assertEquals(command, parser.parseCommand(validAddLogCommand));
+        assertEquals(command, parser.parseCommand(validAddLogCommandByAlias));
         assertTrue(parser.parseCommand(validAddLogCommand) instanceof AddLogCommand);
+        assertTrue(parser.parseCommand(validAddLogCommandByAlias) instanceof AddLogCommand);
     }
 
     @Test
@@ -170,14 +222,21 @@ public class AddressBookParserTest {
     public void parseCommand_addevent() throws Exception {
         Event event = new EventBuilder().build();
         AddEventCommand command = (AddEventCommand) parser.parseCommand(EventUtil.getAddEventCommand(event));
+        AddEventCommand commandByAlias = (AddEventCommand) parser.parseCommand(EventUtil.getAddEventCommandAlias(event));
+
         assertEquals(new AddEventCommand(event), command);
+        assertEquals(new AddEventCommand(event), commandByAlias);
     }
 
     @Test
     public void parseCommand_deleteevent() throws Exception {
         DeleteEventCommand command = (DeleteEventCommand) parser.parseCommand(
                 DeleteEventCommand.COMMAND_WORD + " " + INDEX_FIRST_EVENT.getOneBased());
+        DeleteEventCommand commandByAlias = (DeleteEventCommand) parser.parseCommand(
+                DeleteEventCommand.COMMAND_ALIAS + " " + INDEX_FIRST_EVENT.getOneBased());
         assertEquals(new DeleteEventCommand(INDEX_FIRST_EVENT), command);
+        assertEquals(new DeleteEventCommand(INDEX_FIRST_EVENT), commandByAlias);
+
     }
 
     @Test
@@ -188,7 +247,14 @@ public class AddressBookParserTest {
                 FindEventCommand.COMMAND_WORD + " " + PREFIX_NAME + DEFAULT_NAME_SUBSTRING
                 + " " + PREFIX_DATE + DEFAULT_DATE + " " + PREFIX_FRIEND_NAME + DEFAULT_FRIEND_NAME_SUBSTRING_1
                 + " " + PREFIX_FRIEND_NAME + DEFAULT_FRIEND_NAME_SUBSTRING_2);
+
+        FindEventCommand commandByAlias = (FindEventCommand) parser.parseCommand(
+                FindEventCommand.COMMAND_ALIAS + " " + PREFIX_NAME + DEFAULT_NAME_SUBSTRING
+                        + " " + PREFIX_DATE + DEFAULT_DATE + " " + PREFIX_FRIEND_NAME + DEFAULT_FRIEND_NAME_SUBSTRING_1
+                        + " " + PREFIX_FRIEND_NAME + DEFAULT_FRIEND_NAME_SUBSTRING_2);
+
         assertEquals(new FindEventCommand(predicate), command);
+        assertEquals(new FindEventCommand(predicate), commandByAlias);
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/EventUtil.java
+++ b/src/test/java/seedu/address/testutil/EventUtil.java
@@ -21,6 +21,14 @@ public class EventUtil {
     }
 
     /**
+     * Returns an addevent command string (command alias version) for adding the {@code event}.
+     */
+    public static String getAddEventCommandAlias(Event event) {
+        return AddEventCommand.COMMAND_ALIAS + " " + getEventDetails(event);
+    }
+
+
+    /**
      * Returns the part of command string for the given {@code event}'s details.
      */
     public static String getEventDetails(Event event) {

--- a/src/test/java/seedu/address/testutil/PersonUtil.java
+++ b/src/test/java/seedu/address/testutil/PersonUtil.java
@@ -33,6 +33,13 @@ public class PersonUtil {
     }
 
     /**
+     * Returns an add command string (command alias version) for adding the {@code person}.
+     */
+    public static String getAddCommandAlias(Person person) {
+        return AddCommand.COMMAND_ALIAS + " " + getPersonDetails(person);
+    }
+
+    /**
      * Returns the part of command string for the given {@code person}'s details.
      */
     public static String getPersonDetails(Person person) {


### PR DESCRIPTION
Summary of changes made
- Added command aliases for commands so that experienced users can enter commands more efficiently
- Added test cases to ensure that the command aliases work 
- Changed `COMMAND_WORD` from `showfriends` to `listfriends` to prevent confusion between `showfriend` and `showfriends` and also changed `showevents` to `listevents` ,  maintain consistency. 

fixes #155
fixes #157