### PR TITLE
Fix `editlog` bug

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLogCommand.java
@@ -219,8 +219,8 @@ public class EditLogCommand extends ByIndexByNameCommand {
                     this.newDescription != null ? this.newDescription : initialLog.getDescription()); // create log to be added
 
             // another sanity check
-            if (personToEdit.containsLogExactly(editedLog)) {
-                throw new CommandException(MESSAGE_DUPLICATE_LOG); // ensure not a duplicate log being inserted
+            if (personToEdit.containsLog(editedLog) && !initialLog.isSameLog(editedLog)) {
+                throw new CommandException(MESSAGE_DUPLICATE_LOG); // ensure edited log does not duplicate with existing
             }
 
             // set log

--- a/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
@@ -12,6 +12,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LOG;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.KAREN;
+import static seedu.address.testutil.TypicalPersons.LAUREN;
+import static seedu.address.testutil.TypicalPersons.MAVIS;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -343,11 +345,10 @@ public class EditLogCommandTest {
         // ===== WITH NAME =====
         // command
         EditLogCommand.EditLogDescriptor descriptor = new EditLogCommand.EditLogDescriptor();
-        descriptor.setNewTitle(KAREN.getLogs().get(0).getTitle().toString()); // has one log
-        descriptor.setNewDescription(KAREN.getLogs().get(0).getDescription().toString());
+        descriptor.setNewTitle(MAVIS.getLogs().get(2).getTitle().toString()); // has three logs, get third
         EditLogCommand command = new EditLogCommand(
-                KAREN.getName(), // ninth person in typical address book
-                Index.fromOneBased(1), // first log
+                MAVIS.getName(), // ninth person in typical address book
+                Index.fromOneBased(1), // try to edit 1st log to be same as 3rd log
                 descriptor);
 
         assertCommandFailure(command, model, MESSAGE_DUPLICATE_LOG);
@@ -355,13 +356,14 @@ public class EditLogCommandTest {
         // ===== WITH INDEX =====
         // command
         descriptor = new EditLogCommand.EditLogDescriptor();
-        descriptor.setNewTitle(KAREN.getLogs().get(0).getTitle().toString()); // has one log
-        descriptor.setNewDescription(KAREN.getLogs().get(0).getDescription().toString());
+        descriptor.setNewTitle(MAVIS.getLogs().get(2).getTitle().toString()); // has three logs, get third
         command = new EditLogCommand(
-                Index.fromOneBased(9), // ninth person in typical address book
-                Index.fromOneBased(1), // first log
+                Index.fromOneBased(11), // ninth person in typical address book
+                Index.fromOneBased(1), // try to edit 1st log to be same as 3rd log
                 descriptor);
         assertCommandFailure(command, model, MESSAGE_DUPLICATE_LOG);
+
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
@@ -12,7 +12,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LOG;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.KAREN;
-import static seedu.address.testutil.TypicalPersons.LAUREN;
 import static seedu.address.testutil.TypicalPersons.MAVIS;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 


### PR DESCRIPTION
Fixes #198 

Previously, `editlog` did not correctly handle cases where a user edited a log to be the same as an existing log, because the wrong equality check method was called (duplicate checks were being done by logs having same title AND description, which is not allowed).

This bug has been fixed and one test case has been added to verify the behaviour.

