### PR TITLE
Fix dynamic updating for `showinsights`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/EditLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditLogCommand.java
@@ -219,8 +219,8 @@ public class EditLogCommand extends ByIndexByNameCommand {
                     this.newDescription != null ? this.newDescription : initialLog.getDescription()); // create log to be added
 
             // another sanity check
-            if (personToEdit.containsLogExactly(editedLog)) {
-                throw new CommandException(MESSAGE_DUPLICATE_LOG); // ensure not a duplicate log being inserted
+            if (personToEdit.containsLog(editedLog) && !initialLog.isSameLog(editedLog)) {
+                throw new CommandException(MESSAGE_DUPLICATE_LOG); // ensure edited log does not duplicate with existing
             }
 
             // set log

--- a/src/main/java/seedu/address/logic/commands/ShowInsightsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowInsightsCommand.java
@@ -7,6 +7,7 @@ import seedu.address.model.Model;
 public class ShowInsightsCommand extends Command {
 
     public static final String COMMAND_WORD = "showinsights";
+    public static final String COMMAND_ALIAS = "si";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows insights about friends in Amigos.\n";
 

--- a/src/main/java/seedu/address/logic/commands/ShowInsightsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ShowInsightsCommand.java
@@ -20,7 +20,8 @@ public class ShowInsightsCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model); // sanity check
-        // simply directs UI to show
+
+        // simply directs UI to show, since UI handles updating
         return new CommandResult(MESSAGE_SUCCESS, false, false, false, false, true);
     }
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -117,7 +117,9 @@ public class AddressBookParser {
 
 
         case ShowInsightsCommand.COMMAND_WORD:
+        case ShowInsightsCommand.COMMAND_ALIAS:
             return new ShowInsightsCommand();
+
         case FindEventCommand.COMMAND_WORD:
         case FindEventCommand.COMMAND_ALIAS:
             return new FindEventCommandParser().parse(arguments);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -179,8 +179,8 @@ public class AddressBook implements ReadOnlyAddressBook {
     public ObservableList<PersonInsight> getInsightsList(Model model) {
         return FXCollections.observableArrayList(this.getPersonList()
                 .stream()
-                .sorted(Comparator.reverseOrder())
                 .map(person -> new PersonInsight(person, model))
+                .sorted(Comparator.reverseOrder())
                 .collect(Collectors.toList()));
     }
 

--- a/src/main/java/seedu/address/model/person/Log.java
+++ b/src/main/java/seedu/address/model/person/Log.java
@@ -65,8 +65,7 @@ public class Log {
     @Override
     public String toString() {
         return this.title + "\n"
-                + (this.description.value == null ? "" : this.description)
-                + "\n\n";
+                + (this.description.value == null ? "" : this.description + "\n");
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -206,6 +206,9 @@ public class MainWindow extends UiPart<Stage> {
         boolean isExpandedCard = commandResult.isShowFriendCommand();
         if (showInsight) {
             tabs.getSelectionModel().select(personInsightsListTab);
+            // dynamically reload component
+            personInsightListPanel = new PersonInsightListPanel(logic.getInsightsList());
+            personInsightListPanelPlaceholder.getChildren().set(0, personInsightListPanel.getRoot());
             personInsightListPanelPlaceholder.requestFocus();
         } else if (event) {
             tabs.getSelectionModel().select(eventsListTab);

--- a/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
@@ -12,6 +12,8 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LOG;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.KAREN;
+import static seedu.address.testutil.TypicalPersons.LAUREN;
+import static seedu.address.testutil.TypicalPersons.MAVIS;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
@@ -343,11 +345,10 @@ public class EditLogCommandTest {
         // ===== WITH NAME =====
         // command
         EditLogCommand.EditLogDescriptor descriptor = new EditLogCommand.EditLogDescriptor();
-        descriptor.setNewTitle(KAREN.getLogs().get(0).getTitle().toString()); // has one log
-        descriptor.setNewDescription(KAREN.getLogs().get(0).getDescription().toString());
+        descriptor.setNewTitle(MAVIS.getLogs().get(2).getTitle().toString()); // has three logs, get third
         EditLogCommand command = new EditLogCommand(
-                KAREN.getName(), // ninth person in typical address book
-                Index.fromOneBased(1), // first log
+                MAVIS.getName(), // ninth person in typical address book
+                Index.fromOneBased(1), // try to edit 1st log to be same as 3rd log
                 descriptor);
 
         assertCommandFailure(command, model, MESSAGE_DUPLICATE_LOG);
@@ -355,13 +356,14 @@ public class EditLogCommandTest {
         // ===== WITH INDEX =====
         // command
         descriptor = new EditLogCommand.EditLogDescriptor();
-        descriptor.setNewTitle(KAREN.getLogs().get(0).getTitle().toString()); // has one log
-        descriptor.setNewDescription(KAREN.getLogs().get(0).getDescription().toString());
+        descriptor.setNewTitle(MAVIS.getLogs().get(2).getTitle().toString()); // has three logs, get third
         command = new EditLogCommand(
-                Index.fromOneBased(9), // ninth person in typical address book
-                Index.fromOneBased(1), // first log
+                Index.fromOneBased(11), // ninth person in typical address book
+                Index.fromOneBased(1), // try to edit 1st log to be same as 3rd log
                 descriptor);
         assertCommandFailure(command, model, MESSAGE_DUPLICATE_LOG);
+
+
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditLogCommandTest.java
@@ -12,7 +12,6 @@ import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_LOG;
 import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_PERSON;
 import static seedu.address.testutil.TypicalPersons.KAREN;
-import static seedu.address.testutil.TypicalPersons.LAUREN;
 import static seedu.address.testutil.TypicalPersons.MAVIS;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 


### PR DESCRIPTION
Fixes #213 

At show insights, previously no call was made to refresh the list when
the command was called. Now, the MainWindow component, when called to
switch tabs, will dynamically request for a new list from the logic
component.

As an aside, the proper way to do this is probably to have a
`UniqueInsightsList`, or alternatively to have a new field in
`CommandResult`, but both seem unnecessary given the time constraints.

Also, added command alias for `showinsights` as si.