### PR TITLE
Lognames not allowed to be one character long

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -315,6 +315,7 @@ Please do not manually edit the save file to avoid the risk of data corruption.
 --------------------------------------------------------------------------------------------------------------------
 
 ## Command summary
+
 | Action                     | Command Alias | Format, Examples                                                                                                                                                                                                                                                       |
 |----------------------------|---------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | **Add Friend**             | `af`          | `addfriend n/NAME  [p/PHONE_NUMBER] [e/EMAIL]  [a/ADDRESS] [d/DESCRIPTION] [t/TAG]...` <br> e.g., `addfriend n/John Doe p/98765432 e/johnd@example.com a/John street, block 123, #01-01 d/Physics Major, Sarah’s friend. Met at Freshman Dinner. t/friend t/classmate` |

--- a/src/main/java/seedu/address/model/person/LogName.java
+++ b/src/main/java/seedu/address/model/person/LogName.java
@@ -21,7 +21,7 @@ public class LogName extends Name {
      * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
-    public static final String VALIDATION_REGEX = "^[\\p{Alnum}\\p{Punct}][\\p{Alnum}\\p{Punct}\\s]{1," + (TITLE_LENGTH_CONSTRAINT - 1) + "}";
+    public static final String VALIDATION_REGEX = "^[\\p{Alnum}\\p{Punct}\\s]{1," + (TITLE_LENGTH_CONSTRAINT - 1) + "}";
 
     /**
      * Constructs a {@code FriendName}.


### PR DESCRIPTION
Fixes #214 

# Summary of Changes

Changed regex to allow `LogName` to be one character long.