### PR TITLE
V1.4 improve expanded person card 

### DIFF
--- a/src/main/java/seedu/address/ui/ExpandedPersonCard.java
+++ b/src/main/java/seedu/address/ui/ExpandedPersonCard.java
@@ -84,8 +84,8 @@ public class ExpandedPersonCard extends UiPart<Region> {
         } else {
             eventsHeader.setText("");
             //forces the size of eventsHeader to be (0, 0)
-            eventsHeader.setMaxSize(0,0);
-            eventsHeader.setMinSize(0,0);
+            eventsHeader.setMaxSize(0, 0);
+            eventsHeader.setMinSize(0, 0);
             //forces the size of upcomingEventsPanelPlaceholder to be (0, 0)
             upcomingEventsPanelPlaceholder.setMaxSize(0, 0);
             upcomingEventsPanelPlaceholder.setMinSize(0, 0);

--- a/src/main/java/seedu/address/ui/ExpandedPersonCard.java
+++ b/src/main/java/seedu/address/ui/ExpandedPersonCard.java
@@ -75,14 +75,21 @@ public class ExpandedPersonCard extends UiPart<Region> {
 
         // displaying upcoming events
         upcomingEventsPanel = new EventListPanel(eventList);
-        upcomingEventsPanelPlaceholder.getChildren().add(upcomingEventsPanel.getRoot());
 
         if (eventList.size() > 0) {
             eventsHeader.setText("Upcoming Events:");
+            eventsHeader.setUnderline(true);
+            upcomingEventsPanelPlaceholder.getChildren().add(upcomingEventsPanel.getRoot());
+
         } else {
             eventsHeader.setText("");
-            upcomingEventsPanelPlaceholder.setMaxHeight(0);
-            upcomingEventsPanelPlaceholder.setMaxWidth(0);
+            //forces the size of eventsHeader to be (0, 0)
+            eventsHeader.setMaxSize(0,0);
+            eventsHeader.setMinSize(0,0);
+            //forces the size of upcomingEventsPanelPlaceholder to be (0, 0)
+            upcomingEventsPanelPlaceholder.setMaxSize(0, 0);
+            upcomingEventsPanelPlaceholder.setMinSize(0, 0);
+
         }
 
         //displaying each log
@@ -90,6 +97,7 @@ public class ExpandedPersonCard extends UiPart<Region> {
 
         if (logList.size() > 0) {
             logsHeader.setText("Logs:");
+            logsHeader.setUnderline(true);
             StringBuilder sb = new StringBuilder();
             int numberOfLogs = logList.size();
             for (int i = 1; i <= numberOfLogs; i++) {

--- a/src/main/java/seedu/address/ui/ExpandedPersonCard.java
+++ b/src/main/java/seedu/address/ui/ExpandedPersonCard.java
@@ -47,7 +47,11 @@ public class ExpandedPersonCard extends UiPart<Region> {
     @FXML
     private FlowPane tags;
     @FXML
+    private Label eventsHeader;
+    @FXML
     private StackPane upcomingEventsPanelPlaceholder;
+    @FXML
+    private Label logsHeader;
     @FXML
     private Label logs;
 
@@ -57,7 +61,7 @@ public class ExpandedPersonCard extends UiPart<Region> {
     public ExpandedPersonCard(Person person, ObservableList<Event> eventList) {
         super(FXML);
         this.person = person;
-        name.setText(person.getName().fullName);
+        name.setText("1. " + person.getName().fullName);
         phone.setText(person.getPhone().value == null ? "" : "Phone: " + person.getPhone().value);
         address.setText(person.getAddress().value == null ? "" : "Address: " + person.getAddress().value);
         email.setText(person.getEmail().value == null ? "" : "Email: " + person.getEmail().value);
@@ -69,18 +73,33 @@ public class ExpandedPersonCard extends UiPart<Region> {
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
+        // displaying upcoming events
         upcomingEventsPanel = new EventListPanel(eventList);
         upcomingEventsPanelPlaceholder.getChildren().add(upcomingEventsPanel.getRoot());
 
-        //displaying each log
-        StringBuilder sb = new StringBuilder();
-        List<Log> logList = person.getLogs();
-        int numberOfLogs = logList.size();
-
-        for (int i = 1; i <= numberOfLogs; i++) {
-            sb.append(i + ". " + logList.get(i - 1).toString() + "\n");
+        if (eventList.size() > 0) {
+            eventsHeader.setText("Upcoming Events:");
+        } else {
+            eventsHeader.setText("");
+            upcomingEventsPanelPlaceholder.setMaxHeight(0);
+            upcomingEventsPanelPlaceholder.setMaxWidth(0);
         }
-        logs.setText(sb.toString());
+
+        //displaying each log
+        List<Log> logList = person.getLogs();
+
+        if (logList.size() > 0) {
+            logsHeader.setText("Logs:");
+            StringBuilder sb = new StringBuilder();
+            int numberOfLogs = logList.size();
+            for (int i = 1; i <= numberOfLogs; i++) {
+                sb.append(i + ". " + logList.get(i - 1).toString() + "\n");
+            }
+            logs.setText(sb.toString());
+        } else {
+            logsHeader.setText("");
+            logs.setText("");
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -138,8 +138,6 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         expandedPersonListPanel =
                 new ExpandedPersonListPanel(logic.getFilteredPersonList(), logic.getFilteredEventList());
-        System.out.println("size of filteredperson list should be 1" + logic.getFilteredPersonList().size());
-        System.out.println("size of filteredevent list should be 1" + logic.getFilteredEventList().size());
 
         expandedPersonListPanelPlaceholder.getChildren();
         expandedPersonListPanelPlaceholder.getChildren().add(expandedPersonListPanel.getRoot());

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -216,6 +216,7 @@ public class MainWindow extends UiPart<Stage> {
         } else {
             tabs.getSelectionModel().select(personListTab);
             if (isExpandedCard) {
+                //force refresh so that size of upcoming events can be detected
                 expandedPersonListPanel = new ExpandedPersonListPanel(logic.getFilteredPersonList(), logic.getFilteredEventList());
                 expandedPersonListPanelPlaceholder.getChildren().set(0, expandedPersonListPanel.getRoot());
                 expandedPersonListPanelPlaceholder.requestFocus();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -138,6 +138,9 @@ public class MainWindow extends UiPart<Stage> {
     void fillInnerParts() {
         expandedPersonListPanel =
                 new ExpandedPersonListPanel(logic.getFilteredPersonList(), logic.getFilteredEventList());
+        System.out.println("size of filteredperson list should be 1" + logic.getFilteredPersonList().size());
+        System.out.println("size of filteredevent list should be 1" + logic.getFilteredEventList().size());
+
         expandedPersonListPanelPlaceholder.getChildren();
         expandedPersonListPanelPlaceholder.getChildren().add(expandedPersonListPanel.getRoot());
 
@@ -213,8 +216,11 @@ public class MainWindow extends UiPart<Stage> {
         } else {
             tabs.getSelectionModel().select(personListTab);
             if (isExpandedCard) {
+                expandedPersonListPanel = new ExpandedPersonListPanel(logic.getFilteredPersonList(), logic.getFilteredEventList());
+                expandedPersonListPanelPlaceholder.getChildren().set(0, expandedPersonListPanel.getRoot());
                 expandedPersonListPanelPlaceholder.requestFocus();
                 expandedPersonListPanelPlaceholder.toFront();
+
             } else {
                 personListPanelPlaceholder.requestFocus();
                 personListPanelPlaceholder.toFront();

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -177,6 +177,13 @@
     -fx-text-fill: #010504;
 }
 
+.cell_header_label {
+    -fx-font-family: "Segoe UI Semibold";
+    -fx-font-size: 16px;
+    -fx-font-style: bold;
+    -fx-text-fill: #010504;
+}
+
 .cell_small_label {
     -fx-font-family: "Segoe UI";
     -fx-font-size: 13px;

--- a/src/main/resources/view/DarkTheme.css
+++ b/src/main/resources/view/DarkTheme.css
@@ -173,7 +173,7 @@
 
 .cell_name_label {
     -fx-font-family: "Segoe UI Semibold";
-    -fx-font-size: 40px;
+    -fx-font-size: 20px;
     -fx-text-fill: #010504;
 }
 

--- a/src/main/resources/view/ExpandedPersonListCard.fxml
+++ b/src/main/resources/view/ExpandedPersonListCard.fxml
@@ -26,6 +26,9 @@
                   <Insets bottom="5.0" />
                </padding>
                </Label>
+            <padding>
+               <Insets top="5.0" />
+            </padding>
       </HBox>
         <FlowPane fx:id="tags" />
        <Label fx:id="description" styleClass="cell_big_label" text="\$description" textOverrun="CLIP" wrapText="true">
@@ -48,16 +51,7 @@
             <font>
                <Font name="System Bold" size="13.0" />
             </font></Label>
-         <Label styleClass="cell_header_label" text="Upcoming Events:" wrapText="true">
-            <VBox.margin>
-               <Insets top="30.0" />
-            </VBox.margin>
-            <font>
-               <Font size="30.0" />
-            </font>
-         </Label>
-         <StackPane fx:id="upcomingEventsPanelPlaceholder" minHeight="-Infinity" prefHeight="100.0" />
-         <Label styleClass="cell_header_label" text="Logs:" wrapText="true">
+         <Label fx:id="eventsHeader" styleClass="cell_big_label" text="\$Upcoming Events:" wrapText="true">
             <VBox.margin>
                <Insets top="30.0" />
             </VBox.margin>
@@ -65,7 +59,16 @@
                <Font size="19.0" />
             </font>
          </Label>
-         <Label fx:id="logs" layoutX="25.0" layoutY="46.0" text="\\$logs" textOverrun="CLIP" wrapText="true">
+         <StackPane fx:id="upcomingEventsPanelPlaceholder" minHeight="-Infinity" prefHeight="100.0" />
+         <Label fx:id="logsHeader" styleClass="cell_big_label" text="\$Logs:" wrapText="true">
+            <VBox.margin>
+               <Insets top="30.0" />
+            </VBox.margin>
+            <font>
+               <Font size="19.0" />
+            </font>
+         </Label>
+         <Label fx:id="logs" layoutX="25.0" layoutY="46.0" text="\$logs" textOverrun="CLIP" wrapText="true">
             <padding>
                <Insets top="5.0" />
             </padding></Label>

--- a/src/main/resources/view/ExpandedPersonListCard.fxml
+++ b/src/main/resources/view/ExpandedPersonListCard.fxml
@@ -51,18 +51,18 @@
             <font>
                <Font name="System Bold" size="13.0" />
             </font></Label>
-         <Label fx:id="eventsHeader" styleClass="cell_big_label" text="\$Upcoming Events:" wrapText="true">
+         <Label fx:id="eventsHeader" styleClass="cell_header_label" text="\$Upcoming Events:" wrapText="true">
             <VBox.margin>
-               <Insets top="30.0" />
+               <Insets top="10.0" />
             </VBox.margin>
             <font>
                <Font size="19.0" />
             </font>
          </Label>
          <StackPane fx:id="upcomingEventsPanelPlaceholder" minHeight="-Infinity" prefHeight="100.0" />
-         <Label fx:id="logsHeader" styleClass="cell_big_label" text="\$Logs:" wrapText="true">
+         <Label fx:id="logsHeader" styleClass="cell_header_label" text="\$Logs:" wrapText="true">
             <VBox.margin>
-               <Insets top="30.0" />
+               <Insets top="10.0" />
             </VBox.margin>
             <font>
                <Font size="19.0" />


### PR DESCRIPTION
modified the expanded person card such that upcoming events header and logs header will not be shown if there are no events and logs respectively. 

- with logs and events 
<img width="778" alt="image" src="https://user-images.githubusercontent.com/77088875/161610153-ec05bf23-15e6-43ff-9916-53080d542d67.png">

- with logs only
<img width="788" alt="image" src="https://user-images.githubusercontent.com/77088875/161610262-6198b4e4-390f-4b92-8e39-92d35e664168.png">


- with events only
<img width="787" alt="image" src="https://user-images.githubusercontent.com/77088875/161610364-d2c9a9a6-e4d1-4f57-a8cc-aec440269bca.png">


- with neither logs nor events 
<img width="786" alt="image" src="https://user-images.githubusercontent.com/77088875/161610406-1544270c-90bc-488d-af59-12df8ef6dee0.png">

