### PR TITLE
Fix deletefriend not updating past events bug.

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -231,6 +231,7 @@ public class MainWindow extends UiPart<Stage> {
             tabs.getSelectionModel().select(eventsListTab);
             eventListPanelPlaceholder.requestFocus();
         } else {
+            logic.execute("le");
             tabs.getSelectionModel().select(personListTab);
             if (isExpandedCard) {
                 //force refresh so that size of upcoming events can be detected


### PR DESCRIPTION
Fixes #241 

# Summary of changes
- Run `listevents` in the background to update the event list.