### PR TITLE
Fix crash when JSON has nulls at load

### DIFF
--- a/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
+++ b/src/main/java/seedu/address/storage/JsonAddressBookStorage.java
@@ -56,6 +56,9 @@ public class JsonAddressBookStorage implements AddressBookStorage {
         } catch (IllegalValueException ive) {
             logger.info("Illegal values found in " + filePath + ": " + ive.getMessage());
             throw new DataConversionException(ive);
+        } catch (NullPointerException ne) {
+            logger.info("Null values found in " + filePath + ": " + ne.getMessage());
+            throw new DataConversionException(ne);
         }
     }
 


### PR DESCRIPTION
Previously, user could sabotage JSON file by adding 'null' values into the JSON, which threw an uncaught `NullPointerException`. Caught now at an appropriate place and handled to restart with a fresh address book.

Fixes #264 