### PR TITLE
Fix friend-related bugs

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -65,12 +65,14 @@ _Amigos_ is designed to help you keep track of the friends in your life.
 
 ### Adding a friend: `addfriend` or `af`
 
-Adds a new friend to _Amigos_. A friend has:
+Adds a new friend to _Amigos_.
 
 **Format**: `addfriend n/NAME  [p/PHONE_NUMBER] [e/EMAIL]  [a/ADDRESS] [d/DESCRIPTION] [t/TAG]…`
 
 * Note that `NAME` field is minimally compulsory. `p/`, `e/`, `a/` and `d/` `t/` flags and their arguments are optional.
-* Note that there can be no duplicate friends having the same name.
+* Note that there can be no duplicate friends having the same name (case-insensitive).
+* Note that names have to be exactly matched (in a case-insensitive manner) to be considered as duplicates. For example,
+  `John Doe` and `John  Doe` (with the extra space) are considered as different friends.
 
 **Examples**:
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -70,6 +70,7 @@ Adds a new friend to _Amigos_.
 **Format**: `addfriend n/NAME  [p/PHONE_NUMBER] [e/EMAIL]  [a/ADDRESS] [d/DESCRIPTION] [t/TAG]…`
 
 * Note that `NAME` field is minimally compulsory. `p/`, `e/`, `a/` and `d/` `t/` flags and their arguments are optional.
+* Note that friend names should only contain alphanumeric characters and spaces
 * Note that there can be no duplicate friends having the same name (case-insensitive).
 * Note that names have to be exactly matched (in a case-insensitive manner) to be considered as duplicates. For example,
   `John Doe` and `John  Doe` (with the extra space) are considered as different friends.

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -27,7 +27,7 @@ import seedu.address.model.tag.Tag;
  */
 public class ParserUtil {
 
-    public static final String MESSAGE_INVALID_INDEX = "Index is not a non-zero unsigned integer.";
+    public static final String MESSAGE_INVALID_INDEX = "The person index provided is invalid";
     public static final DateTimeFormatter INPUT_DATE_FORMATTER = DateTimeFormatter.ofPattern("d-M-yyyy");
     public static final String MESSAGE_INVALID_DATE = "Dates should be given in the format DD-MM-YYYY.";
 

--- a/src/main/java/seedu/address/model/person/Email.java
+++ b/src/main/java/seedu/address/model/person/Email.java
@@ -24,7 +24,8 @@ public class Email {
             + "    - have each domain label consist of alphanumeric characters, separated only by hyphens, if any.";
     // alphanumeric and special characters
     private static final String ALPHANUMERIC_NO_UNDERSCORE = "[^\\W_]+"; // alphanumeric characters except underscore
-    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_NO_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
+    private static final String ALPHANUMERIC_WITH_UNDERSCORE = "[^\\W]+"; // alphanumeric characters
+    private static final String LOCAL_PART_REGEX = "^" + ALPHANUMERIC_WITH_UNDERSCORE + "([" + SPECIAL_CHARACTERS + "]"
             + ALPHANUMERIC_NO_UNDERSCORE + ")*";
     private static final String DOMAIN_PART_REGEX = ALPHANUMERIC_NO_UNDERSCORE
             + "(-" + ALPHANUMERIC_NO_UNDERSCORE + ")*";

--- a/src/main/java/seedu/address/model/person/FriendName.java
+++ b/src/main/java/seedu/address/model/person/FriendName.java
@@ -14,7 +14,7 @@ public class FriendName extends Name {
 
     public static final String MESSAGE_CONSTRAINTS =
             "Friend names should only contain alphanumeric characters and spaces, and it should not be blank"
-            + "or consisting only of whitespace";
+            + " or consisting only of whitespace";
 
     /*
      * The first character of the name must not be a whitespace,

--- a/src/test/java/seedu/address/logic/parser/ShowFriendCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowFriendCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;

--- a/src/test/java/seedu/address/logic/parser/ShowFriendCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/ShowFriendCommandParserTest.java
@@ -1,6 +1,6 @@
 package seedu.address.logic.parser;
 
-import static seedu.address.commons.core.Messages.MESSAGE_INDEX_IS_NOT_NON_ZERO_UNSIGNED_INTEGER;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
 import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
@@ -39,7 +39,7 @@ public class ShowFriendCommandParserTest {
 
     @Test
     public void parse_invalidIndex_throwsParseException() {
-        assertParseFailure(parser, "-1", MESSAGE_INDEX_IS_NOT_NON_ZERO_UNSIGNED_INTEGER);
+        assertParseFailure(parser, "-1", MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
     }
 
 


### PR DESCRIPTION
bugs fixed 
- email regex. changed it to allow _xxx@gmail.com (since RFC allows emails to start with underscore)
- `addfriend` typo in UG
- update `addfriend` in UG to say that spaces between names matter. e.g `John Doe` and `John  Doe` are different people
- changed invalid index error message from `Index is not a non-zero unsigned integer` to `Invalid index provided!`
- add missing space in `deletefriend` error message

fixes #263